### PR TITLE
Fix non-ASCII character crash bug

### DIFF
--- a/toot/console.py
+++ b/toot/console.py
@@ -244,7 +244,7 @@ def _print_accounts(accounts):
     for account in accounts:
         acct = green("@{}".format(account['acct']))
         display_name = account['display_name']
-        print("* {} {}".format(acct, display_name))
+        print("* {} {}".format(acct.encode("utf-8"), display_name.encode("utf-8")))
 
 
 def _print_hashtags(hashtags):

--- a/toot/console.py
+++ b/toot/console.py
@@ -115,7 +115,7 @@ def print_timeline(item):
         return zip_longest(left_column, right_column, fillvalue="")
 
     for left, right in timeline_rows(item):
-        print("{:30} │ {}".format(left, right))
+        print("{:30} │ {}".format(left.encode("utf-8"), right.encode("utf-8")))
 
 
 def parse_timeline(item):

--- a/toot/console.py
+++ b/toot/console.py
@@ -256,7 +256,7 @@ def _print_hashtags(hashtags):
 
 
 def cmd_search(app, user, args):
-    parser = ArgumentParser(prog="toot serach",
+    parser = ArgumentParser(prog="toot search",
                             description="Search for content",
                             epilog="https://github.com/ihabunek/toot")
 


### PR DESCRIPTION
This PR fixes a bug where the program crashes when trying to display non-ASCII characters.

Before:

```
───────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────
 @minerobber                   │ Finally setting up a Mastodon account. Joy!
2017-04-17 05:38               │
                               │
───────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────
tilde.town @tildetown          │ welcome new users!!!!!!~owen~jasp~paladinjack
2017-04-17 05:05               │
                               │
───────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────
Traceback (most recent call last):
  File "/home/minerobber/misc/programming/venv/bin/toot", line 11, in <module>
    sys.exit(main())
  File "/home/minerobber/misc/programming/venv/local/lib/python2.7/site-packages/toot/console.py", line 378, in main
    run_command(command, args)
  File "/home/minerobber/misc/programming/venv/local/lib/python2.7/site-packages/toot/console.py", line 349, in run_command
    return cmd_timeline(app, user, args)
  File "/home/minerobber/misc/programming/venv/local/lib/python2.7/site-packages/toot/console.py", line 150, in cmd_timeline
    print_timeline(item)
  File "/home/minerobber/misc/programming/venv/local/lib/python2.7/site-packages/toot/console.py", line 118, in print_timeline
    print("{:30} │ {}".format(left, right))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```

Now:

```
───────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────
MineRobber @minerobber         │ Finally setting up a Mastodon account. Joy!
2017-04-17 05:38               │
                               │
───────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────
tilde.town @tildetown          │ welcome new users!!!!!!~owen~jasp~paladinjack
2017-04-17 05:05               │
                               │
───────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────
杰西 @m455                   │ @tildetown aw shucks
2017-04-17 02:43               │
                               │
───────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────
(ETC.)
```

I also fixed a typo in the search function handler (s/serach/search/)