### PR TITLE
Add proxy option to config and prepare the requests with it

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -84,8 +84,12 @@ def post_status(app, user, status, visibility='public', media_ids=None):
     }).json()
 
 
-def timeline_home(app, user):
-    return http.get(app, user, '/api/v1/timelines/home').json()
+def timeline_home(app, user, args):
+    if args.tag:
+        timeline = "tag/%s" % args.tag
+    else:
+        timeline = "home"
+    return http.get(app, user, '/api/v1/timelines/%s' % timeline).json()
 
 
 def get_next_path(headers):

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -54,7 +54,7 @@ def _parse_timeline(item):
 
 
 def timeline(app, user, args):
-    items = api.timeline_home(app, user)
+    items = api.timeline_home(app, user, args)
     parsed_items = [_parse_timeline(t) for t in items]
 
     print_out("─" * 31 + "┬" + "─" * 88)

--- a/toot/config.py
+++ b/toot/config.py
@@ -45,6 +45,7 @@ def make_config(path):
         "apps": apps,
         "users": users,
         "active_user": active_user,
+        "proxy" : {},
     }
 
     print_out("Creating config file at <blue>{}</blue>".format(path))
@@ -174,3 +175,20 @@ def activate_user(config, user):
     config['active_user'] = user_id(user)
 
     return config
+
+@modify_config
+def set_proxy(config, proxy):
+    config['proxy'] = proxy
+
+    return config
+
+@modify_config
+def delete_proxy(config):
+    config['proxy'] = None
+
+    return config
+
+def get_proxy():
+    config = load_config()
+
+    return config['proxy']

--- a/toot/console.py
+++ b/toot/console.py
@@ -132,7 +132,12 @@ READ_COMMANDS = [
     Command(
         name="timeline",
         description="Show recent items in your public timeline",
-        arguments=[],
+        arguments=[
+            (["tag"], {
+                "help" : "Search for a tag",
+                "nargs" : "?",
+            }),
+        ],
         require_auth=True,
     ),
     Command(

--- a/toot/http.py
+++ b/toot/http.py
@@ -1,12 +1,13 @@
 from requests import Request, Session
 from toot.exceptions import NotFoundError, ApiError
 from toot.logging import log_request, log_response
-
+from toot import config
 
 def send_request(request, allow_redirects=True):
     log_request(request)
 
     with Session() as session:
+        session.proxies.update(config.get_proxy())
         prepared = session.prepare_request(request)
         response = session.send(prepared, allow_redirects=allow_redirects)
 


### PR DESCRIPTION
I need these changes to be able to use toot behind a mandatory proxy. I am not that fluent in python so I am proposing this as a proof of concept. If you want me to change it so it will fit the upstream sources better, please do tell.

Thanks!