### PR TITLE
Local timeline subcommand

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -55,7 +55,7 @@ def get_browser_login_url(app):
     return "{}/oauth/authorize/?{}".format(app.base_url, urlencode({
         "response_type": "code",
         "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
-        "scope": "read write follow",
+        "scope": SCOPES,
         "client_id": app.client_id,
     }))
 

--- a/toot/api.py
+++ b/toot/api.py
@@ -88,6 +88,10 @@ def timeline_home(app, user):
     return http.get(app, user, '/api/v1/timelines/home').json()
 
 
+def timeline_public(app, user, local=False):
+    return http.get(app, user, '/api/v1/timelines/public', {'local': 'true' if local else 'false'}).json()
+
+
 def get_next_path(headers):
     """Given timeline response headers, returns the path to the next batch"""
     links = headers.get('Link', '')

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -54,7 +54,10 @@ def _parse_timeline(item):
 
 
 def timeline(app, user, args):
-    items = api.timeline_home(app, user)
+    if args.local:
+        items = api.timeline_public(app, user, local=True)
+    else:
+        items = api.timeline_home(app, user)
     parsed_items = [_parse_timeline(t) for t in items]
 
     print_out("─" * 31 + "┬" + "─" * 88)

--- a/toot/console.py
+++ b/toot/console.py
@@ -132,7 +132,13 @@ READ_COMMANDS = [
     Command(
         name="timeline",
         description="Show recent items in your public timeline",
-        arguments=[],
+        arguments=[
+            (["-l", "--local"], {
+                "action": 'store_true',
+                "default": False,
+                "help": "Show local timeline instead of public timeline.",
+            }),
+        ],
         require_auth=True,
     ),
     Command(


### PR DESCRIPTION
Implemented local timeline viewer, which I suggested in #52 .

Usage:
`toot timeline --local`