### PR TITLE
Fix XDG_CONFIG_HOME tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,6 +126,7 @@ def test_get_config_file_path():
     fn = config.get_config_file_path
 
     os.unsetenv('XDG_CONFIG_HOME')
+    os.environ.pop('XDG_CONFIG_HOME', None)
 
     assert fn() == os.path.expanduser('~/.config/toot/config.json')
 


### PR DESCRIPTION
According to the Python documentation[1]:

> Calls to unsetenv() don’t update os.environ, so it is actually
> preferable to delete items of os.environ.

It means that os.unsetenv is not enough to remove an entry from
os.environ. This is why the following test was failing:

    os.unsetenv('XDG_CONFIG_HOME')
    assert fn() == os.path.expanduser('~/.config/toot/config.json')

os.unsetenv did not influence the output of the subsequent call to
os.getenv() in get_config_file_path(). As a result the original value
was returned instead of the fallback value of '~/.config'.

This bug was discovered during porting toot to FreeBSD as the FreeBSD
Ports framework passes XDG_CONFIG_HOME to make's environment.

[1]: https://docs.python.org/3.6/library/os.html#os.unsetenv