### PR TITLE
Add -I / --insecure option, to use HTTP instead of HTTPS.

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -21,6 +21,24 @@ def test_register_app(monkeypatch):
     app = auth.register_app("foo.bar")
     assert_app(app)
 
+def test_register_insecure_app(monkeypatch):
+    app_data = {'id': 100, 'client_id': 'cid', 'client_secret': 'cs'}
+
+    def assert_app(app):
+        assert isinstance(app, App)
+        assert app.instance == "foo.bar"
+        assert app.base_url == "http://foo.bar"
+        assert app.client_id == "cid"
+        assert app.client_secret == "cs"
+
+    monkeypatch.setattr(api, 'create_app', retval(app_data))
+    monkeypatch.setattr(api, 'get_instance', retval({"title": "foo", "version": "1"}))
+    monkeypatch.setattr(config, 'save_app', assert_app)
+
+    app = auth.register_app("foo.bar",
+            insecure=True)
+    assert_app(app)
+
 
 def test_create_app_from_config(monkeypatch):
     """When there is saved config, it's returned"""

--- a/toot/api.py
+++ b/toot/api.py
@@ -16,8 +16,15 @@ def _account_action(app, user, account, action):
     return http.post(app, user, url).json()
 
 
-def create_app(domain):
-    url = 'https://{}/api/v1/apps'.format(domain)
+def create_app(domain,
+        insecure=False):
+
+    if insecure:
+        protocol = 'http'
+    else:
+        protocol = 'https'
+
+    url = protocol+'://{}/api/v1/apps'.format(domain)
 
     data = {
         'client_name': CLIENT_NAME,

--- a/toot/auth.py
+++ b/toot/auth.py
@@ -10,7 +10,8 @@ from toot.exceptions import ApiError, ConsoleError
 from toot.output import print_out
 
 
-def register_app(domain):
+def register_app(domain,
+        insecure=False):
     print_out("Looking up instance info...")
     instance = api.get_instance(domain)
 
@@ -19,11 +20,15 @@ def register_app(domain):
 
     try:
         print_out("Registering application...")
-        response = api.create_app(domain)
+        response = api.create_app(domain,
+                insecure=insecure)
     except ApiError:
         raise ConsoleError("Registration failed.")
 
-    base_url = 'https://' + domain
+    if insecure:
+        base_url = 'http://' + domain
+    else:
+        base_url = 'https://' + domain
 
     app = App(domain, base_url, response['client_id'], response['client_secret'])
     config.save_app(app)
@@ -33,15 +38,15 @@ def register_app(domain):
     return app
 
 
-def create_app_interactive(instance=None):
+def create_app_interactive(instance=None,
+        insecure=False):
     if not instance:
         print_out("Choose an instance [<green>{}</green>]: ".format(DEFAULT_INSTANCE), end="")
         instance = input()
         if not instance:
             instance = DEFAULT_INSTANCE
 
-    return config.load_app(instance) or register_app(instance)
-
+    return config.load_app(instance) or register_app(instance, insecure)
 
 def create_user(app, access_token):
     # Username is not yet known at this point, so fetch it from Mastodon

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -116,7 +116,8 @@ def auth(app, user, args):
 
 
 def login(app, user, args):
-    app = create_app_interactive(instance=args.instance)
+    app = create_app_interactive(instance=args.instance,
+            insecure=args.insecure)
     login_interactive(app, args.email)
 
     print_out()
@@ -124,7 +125,8 @@ def login(app, user, args):
 
 
 def login_browser(app, user, args):
-    app = create_app_interactive(instance=args.instance)
+    app = create_app_interactive(instance=args.instance,
+            insecure=args.insecure)
     login_browser_interactive(app)
 
     print_out()

--- a/toot/console.py
+++ b/toot/console.py
@@ -34,6 +34,11 @@ common_args = [
         "help": "show debug log in console",
         "action": 'store_true',
         "default": False,
+    }),
+    (["--accept-invalid-certs"], {
+        "help": "accept invalid HTTPS certificates",
+        "action": 'store_true',
+        "default": False,
     })
 ]
 
@@ -51,18 +56,23 @@ email_arg = (["-e", "--email"], {
     "help": 'email address to log in with',
 })
 
+insecure_arg = (["-I", "--insecure"], {
+    "action": 'store_true',
+    "default": False,
+    "help": 'use HTTP, not HTTPS',
+})
 
 AUTH_COMMANDS = [
     Command(
         name="login",
         description="Log in from the console, does NOT support two factor authentication",
-        arguments=[instance_arg, email_arg],
+        arguments=[instance_arg, email_arg, insecure_arg],
         require_auth=False,
     ),
     Command(
         name="login_browser",
         description="Log in using your browser, supports regular and two factor authentication",
-        arguments=[instance_arg],
+        arguments=[instance_arg, insecure_arg],
         require_auth=False,
     ),
     Command(


### PR DESCRIPTION
Add ability to use HTTP instead of HTTPS. This is useful for testing new servers.

Perhaps we should advertise more obviously that this is not recommended in production.

Ref #56 .