### PR TITLE
Converting `&apos` and `&apos;` to an apostrophe

### DIFF
--- a/toot/output.py
+++ b/toot/output.py
@@ -149,7 +149,7 @@ def print_timeline(items):
         reblogged = item['reblog']['account']['username'] if item['reblog'] else None
 
         soup = BeautifulSoup(content, "html.parser")
-        text = soup.get_text().replace('&apos;', "'")
+        text = re.sub("&apos;*", "'", soup.get_text())
         time = datetime.strptime(item['created_at'], "%Y-%m-%dT%H:%M:%S.%fZ")
 
         return {

--- a/toot/utils.py
+++ b/toot/utils.py
@@ -11,7 +11,8 @@ from toot.exceptions import ConsoleError
 
 def get_text(html):
     """Converts html to text, strips all tags."""
-    text = BeautifulSoup(html, "html.parser").get_text().replace('&apos;', "'")
+    text = BeautifulSoup(html, "html.parser").get_text()
+    text = re.sub('&apos;*', "'", text)
 
     return unicodedata.normalize('NFKC', text)
 


### PR DESCRIPTION
Sometimes toots come through that don't have the semicolon. This should get
both cases.