### PR TITLE
Feature proposal: --disable-https flag

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -58,6 +58,15 @@ You will be redirected to your Mastodon instance to log in and authorize toot to
 
 The application and user access tokens will be saved in the configuration file located at ``~/.config/toot/instances/config.json``.
 
+Disabling HTTPS
+~~~~~~~~~~~~~~~
+
+You may pass the ``--disable-https`` flag to use unencrypted HTTP instead of HTTPS for a given instance. This is inherently insecure and should be used only when connecting to local development instances.
+
+.. code-block:: sh
+
+    toot login --disable-https --instance localhost:8080
+
 Using multiple accounts
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/toot/api.py
+++ b/toot/api.py
@@ -17,8 +17,8 @@ def _account_action(app, user, account, action):
     return http.post(app, user, url).json()
 
 
-def create_app(domain):
-    url = 'https://{}/api/v1/apps'.format(domain)
+def create_app(domain, scheme='https'):
+    url = '{}://{}/api/v1/apps'.format(scheme, domain)
 
     data = {
         'client_name': CLIENT_NAME,

--- a/toot/auth.py
+++ b/toot/auth.py
@@ -10,7 +10,7 @@ from toot.exceptions import ApiError, ConsoleError
 from toot.output import print_out
 
 
-def register_app(domain):
+def register_app(domain, scheme='https'):
     print_out("Looking up instance info...")
     instance = api.get_instance(domain)
 
@@ -19,11 +19,11 @@ def register_app(domain):
 
     try:
         print_out("Registering application...")
-        response = api.create_app(domain)
+        response = api.create_app(domain, scheme)
     except ApiError:
         raise ConsoleError("Registration failed.")
 
-    base_url = 'https://' + domain
+    base_url = scheme + '://' + domain
 
     app = App(domain, base_url, response['client_id'], response['client_secret'])
     config.save_app(app)
@@ -33,14 +33,14 @@ def register_app(domain):
     return app
 
 
-def create_app_interactive(instance=None):
+def create_app_interactive(instance=None, scheme='https'):
     if not instance:
         print_out("Choose an instance [<green>{}</green>]: ".format(DEFAULT_INSTANCE), end="")
         instance = input()
         if not instance:
             instance = DEFAULT_INSTANCE
 
-    return config.load_app(instance) or register_app(instance)
+    return config.load_app(instance) or register_app(instance, scheme)
 
 
 def create_user(app, access_token):

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -96,7 +96,7 @@ def auth(app, user, args):
 
 
 def login_cli(app, user, args):
-    app = create_app_interactive(instance=args.instance)
+    app = create_app_interactive(instance=args.instance, scheme=args.scheme)
     login_interactive(app, args.email)
 
     print_out()
@@ -104,7 +104,7 @@ def login_cli(app, user, args):
 
 
 def login(app, user, args):
-    app = create_app_interactive(instance=args.instance)
+    app = create_app_interactive(instance=args.instance, scheme=args.scheme)
     login_browser_interactive(app)
 
     print_out()

--- a/toot/console.py
+++ b/toot/console.py
@@ -56,18 +56,26 @@ email_arg = (["-e", "--email"], {
     "help": 'email address to log in with',
 })
 
+scheme_arg = (["--disable-https"], {
+    "help": "disable HTTPS and use insecure HTTP",
+    "dest": "scheme",
+    "default": "https",
+    "action": "store_const",
+    "const": "http",
+})
+
 
 AUTH_COMMANDS = [
     Command(
         name="login",
         description="Log into a mastodon instance using your browser (recommended)",
-        arguments=[instance_arg],
+        arguments=[instance_arg, scheme_arg],
         require_auth=False,
     ),
     Command(
         name="login_cli",
         description="Log in from the console, does NOT support two factor authentication",
-        arguments=[instance_arg, email_arg],
+        arguments=[instance_arg, email_arg, scheme_arg],
         require_auth=False,
     ),
     Command(


### PR DESCRIPTION
`toot` is a great tool for testing modifications to local Mastodon or Pleroma instances, but it needs a way to switch off HTTPS. This change adds a `--disable-https` flag to `toot login` and `toot login_cli`, as well as a `scheme` argument to login-related API methods that don't use `App.base_url`.