### PR TITLE
Status ID + thread view

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -17,10 +17,17 @@ def _account_action(app, user, account, action):
     return http.post(app, user, url).json()
 
 
-def _status_action(app, user, status_id, action):
-    url = '/api/v1/statuses/{}/{}'.format(status_id, action)
+def _status_action(app, user, status_id, action, method='post'):
+    if action is None:
+        url = '/api/v1/statuses/{}'.format(status_id)
+        method = 'get'
+    else:
+        url = '/api/v1/statuses/{}/{}'.format(status_id, action)
 
-    return http.post(app, user, url).json()
+    if method == 'post':
+        return http.post(app, user, url).json()
+    elif method == 'get':
+        return http.get(app, user, url).json()
 
 
 def create_app(domain, scheme='https'):
@@ -143,6 +150,8 @@ def pin(app, user, status_id):
 def unpin(app, user, status_id):
     return _status_action(app, user, status_id, 'unpin')
 
+def context(app, user, status_id):
+    return _status_action(app, user, status_id, 'context', method='get')
 
 def timeline_home(app, user):
     return http.get(app, user, '/api/v1/timelines/home').json()
@@ -244,6 +253,9 @@ def unblock(app, user, account):
 def verify_credentials(app, user):
     return http.get(app, user, '/api/v1/accounts/verify_credentials').json()
 
+
+def single_status(app, user, status_id):
+    return _status_action(app, user, status_id, None, method='get')
 
 def get_notifications(app, user):
     return http.get(app, user, '/api/v1/notifications').json()

--- a/toot/api.py
+++ b/toot/api.py
@@ -17,17 +17,10 @@ def _account_action(app, user, account, action):
     return http.post(app, user, url).json()
 
 
-def _status_action(app, user, status_id, action, method='post'):
-    if action is None:
-        url = '/api/v1/statuses/{}'.format(status_id)
-        method = 'get'
-    else:
-        url = '/api/v1/statuses/{}/{}'.format(status_id, action)
+def _status_action(app, user, status_id, action):
+    url = '/api/v1/statuses/{}/{}'.format(status_id, action)
 
-    if method == 'post':
-        return http.post(app, user, url).json()
-    elif method == 'get':
-        return http.get(app, user, url).json()
+    return http.post(app, user, url).json()
 
 
 def create_app(domain, scheme='https'):
@@ -150,8 +143,12 @@ def pin(app, user, status_id):
 def unpin(app, user, status_id):
     return _status_action(app, user, status_id, 'unpin')
 
+
 def context(app, user, status_id):
-    return _status_action(app, user, status_id, 'context', method='get')
+    url = '/api/v1/statuses/{}/context'.format(status_id)
+
+    return http.get(app, user, url).json()
+
 
 def timeline_home(app, user):
     return http.get(app, user, '/api/v1/timelines/home').json()
@@ -255,7 +252,10 @@ def verify_credentials(app, user):
 
 
 def single_status(app, user, status_id):
-    return _status_action(app, user, status_id, None, method='get')
+    url = '/api/v1/statuses/{}'.format(status_id)
+
+    return http.get(app, user, url).json()
+
 
 def get_notifications(app, user):
     return http.get(app, user, '/api/v1/notifications').json()

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -29,6 +29,19 @@ def timeline(app, user, args):
 
     print_timeline(items)
 
+def thread(app, user, args):
+    toot = api.single_status(app, user, args.status_id)
+    context = api.context(app, user, args.status_id)
+    thread = []
+    for item in context['ancestors']:
+        thread.append(item)
+
+    thread.append(toot)
+
+    for item in context['descendants']:
+        thread.append(item)
+
+    print_timeline(thread)
 
 def curses(app, user, args):
     from toot.ui.app import TimelineApp

--- a/toot/console.py
+++ b/toot/console.py
@@ -156,7 +156,7 @@ READ_COMMANDS = [
     ),
     Command(
         name="thread",
-        description="Show toot thfread items",
+        description="Show toot thread items",
         arguments=[
             (["status_id"], {
                 "help": "Show thread for toot.",

--- a/toot/console.py
+++ b/toot/console.py
@@ -155,6 +155,16 @@ READ_COMMANDS = [
         require_auth=True,
     ),
     Command(
+        name="thread",
+        description="Show toot thfread items",
+        arguments=[
+            (["status_id"], {
+                "help": "Show thread for toot.",
+            }),
+        ],
+        require_auth=True,
+    ),
+    Command(
         name="timeline",
         description="Show recent items in a timeline (home by default)",
         arguments=[

--- a/toot/output.py
+++ b/toot/output.py
@@ -137,6 +137,11 @@ def print_timeline(items):
             if item['reblogged']:
                 left_column.append("Reblogged @{}".format(item['reblogged']))
 
+            if item['reply_to_toot'] is not None:
+                left_column.append('[RE]')
+
+            left_column.append("id: {}".format(item['id']))
+
             right_column = wrap_text(item['text'], 80)
 
             return zip_longest(left_column, right_column, fillvalue="")
@@ -153,10 +158,12 @@ def print_timeline(items):
         time = datetime.strptime(item['created_at'], "%Y-%m-%dT%H:%M:%S.%fZ")
 
         return {
+            "id": item['id'],
             "account": item['account'],
             "text": text,
             "time": time,
             "reblogged": reblogged,
+            "reply_to_toot": item['in_reply_to_id']
         }
 
     print_out("─" * 31 + "┬" + "─" * 88)


### PR DESCRIPTION
 - Status ID on timeline list view
 - thread command to view a complete thread
   Display order:
    - ancestors
    - status
    - descendants

Thread example output:
```
(.toot) Ξ yitsushi/toot git:(add-toot-id-on-timeline) ▶ toot thread 101444074484291729
───────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────
Efertone                       │ This is a test toot using the toot python cli tool.I was looking for a client on
@efertone                      │ command line, but most of themwere JavaScript and I don't really want a Node
2019-01-19 16:00               │ command line tool.This seems pretty good, but can be improved, so let's
id: 101444066248416936         │ contributein the near future. (let's see how it posts if I break linesaround 80
                               │ characters (because that's a habit, I don't like long lines)\o just ignore this
                               │ toot ;)
───────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────
Efertone                       │ it's hard to figure out what's the toot id and reply on itwithout the curses
@efertone                      │ client :(
2019-01-19 16:02               │
[RE]                           │
id: 101444074484291729         │
───────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────
```

On timeline view it shows lines the same (same `print_timeline` call)