### PR TITLE
Handle notifications

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -545,6 +545,20 @@ def test_notifications(mock_get, capsys):
         "",
     ])
 
+@mock.patch('toot.http.get')
+def test_notifications_empty(mock_get, capsys):
+    mock_get.return_value = MockResponse([])
+
+    console.run_command(app, user, 'notifications', [])
+
+    mock_get.assert_called_once_with(app, user, '/api/v1/notifications')
+
+    out, err = capsys.readouterr()
+    out = uncolorize(out)
+
+    assert not err
+    assert out == "No notification\n"
+
 
 @mock.patch('toot.http.post')
 def test_notifications_clear(mock_post, capsys):

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -546,6 +546,17 @@ def test_notifications(mock_get, capsys):
     ])
 
 
+@mock.patch('toot.http.post')
+def test_notifications_clear(mock_post, capsys):
+    console.run_command(app, user, 'notifications', ['--clear'])
+    out, err = capsys.readouterr()
+    out = uncolorize(out)
+
+    mock_post.assert_called_once_with(app, user, '/api/v1/notifications/clear')
+    assert not err
+    assert out == 'Cleared notifications\n'
+
+
 def u(user_id, access_token="abc"):
     username, instance = user_id.split("@")
     return {

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -436,6 +436,116 @@ def test_whoami(mock_get, capsys):
     assert "Statuses: 19" in out
 
 
+@mock.patch('toot.http.get')
+def test_notifications(mock_get, capsys):
+    mock_get.return_value = MockResponse([{
+        'id': '1',
+        'type': 'follow',
+        'created_at': '2019-02-16T07:01:20.714Z',
+        'account': {
+            'display_name': 'Frank Zappa',
+            'acct': 'frank@zappa.social',
+        },
+    }, {
+        'id': '2',
+        'type': 'mention',
+        'created_at': '2017-01-12T12:12:12.0Z',
+        'account': {
+            'display_name': 'Dweezil Zappa',
+            'acct': 'dweezil@zappa.social',
+        },
+        'status': {
+            'id': '111111111111111111',
+            'account': {
+                'display_name': 'Dweezil Zappa',
+                'acct': 'dweezil@zappa.social',
+            },
+            'created_at': '2017-04-12T15:53:18.174Z',
+            'content': "<p>We still have fans in 2017 @fan123</p>",
+            'reblog': None,
+            'in_reply_to_id': None,
+            'media_attachments': [],
+        },
+    }, {
+        'id': '3',
+        'type': 'reblog',
+        'created_at': '1983-11-03T03:03:03.333Z',
+        'account': {
+            'display_name': 'Terry Bozzio',
+            'acct': 'terry@bozzio.social',
+        },
+        'status': {
+            'id': '1234',
+            'account': {
+                'display_name': 'Zappa Fan',
+                'acct': 'fan123@zappa-fans.social'
+            },
+            'created_at': '1983-11-04T15:53:18.174Z',
+            'content': "<p>The Black Page, a masterpiece</p>",
+            'reblog': None,
+            'in_reply_to_id': None,
+            'media_attachments': [],
+        },
+    }, {
+        'id': '4',
+        'type': 'favourite',
+        'created_at': '1983-12-13T01:02:03.444Z',
+        'account': {
+            'display_name': 'Zappa Old Fan',
+            'acct': 'fan9@zappa-fans.social',
+        },
+        'status': {
+            'id': '1234',
+            'account': {
+                'display_name': 'Zappa Fan',
+                'acct': 'fan123@zappa-fans.social'
+            },
+            'created_at': '1983-11-04T15:53:18.174Z',
+            'content': "<p>The Black Page, a masterpiece</p>",
+            'reblog': None,
+            'in_reply_to_id': None,
+            'media_attachments': [],
+        },
+    }])
+
+    console.run_command(app, user, 'notifications', [])
+
+    mock_get.assert_called_once_with(app, user, '/api/v1/notifications')
+
+    out, err = capsys.readouterr()
+    out = uncolorize(out)
+
+    width = 100
+    assert not err
+    assert out == "\n".join([
+        "─" * width,
+        "Frank Zappa @frank@zappa.social now follows you",
+        "─" * width,
+        "Dweezil Zappa @dweezil@zappa.social mentioned you in",
+        "Dweezil Zappa @dweezil@zappa.social                                                 2017-04-12 15:53",
+        "",
+        "We still have fans in 2017 @fan123",
+        "",
+        "ID 111111111111111111  ",
+        "─" * width,
+        "Zappa Old Fan @fan9@zappa-fans.social favourited your status",
+        "Zappa Fan @fan123@zappa-fans.social                                                 1983-11-04 15:53",
+        "",
+        "The Black Page, a masterpiece",
+        "",
+        "ID 1234  ",
+        "─" * width,
+        "Terry Bozzio @terry@bozzio.social reblogged your status",
+        "Zappa Fan @fan123@zappa-fans.social                                                 1983-11-04 15:53",
+        "",
+        "The Black Page, a masterpiece",
+        "",
+        "ID 1234  ",
+        "─" * width,
+        "",
+    ])
+
+
 def u(user_id, access_token="abc"):
     username, instance = user_id.split("@")
     return {

--- a/toot/api.py
+++ b/toot/api.py
@@ -260,6 +260,10 @@ def get_notifications(app, user):
     return http.get(app, user, '/api/v1/notifications').json()
 
 
+def clear_notifications(app, user):
+    http.post(app, user, '/api/v1/notifications/clear')
+
+
 def get_instance(domain, scheme="https"):
     url = "{}://{}/api/v1/instance".format(scheme, domain)
     return http.anon_get(url).json()

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -304,8 +304,13 @@ def notifications(app, user, args):
         print_out("<green>Cleared notifications</green>")
         return
 
+    notifications = api.get_notifications(app, user)
+    if not notifications:
+        print_out("<yellow>No notification</yellow>")
+        return
+
     width = 100
-    for notification in sorted(api.get_notifications(app, user),
+    for notification in sorted(notifications,
                                key=lambda n: datetime.strptime(
                                    n["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"),
                                reverse=True):

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -299,6 +299,11 @@ def instance(app, user, args):
 
 
 def notifications(app, user, args):
+    if args.clear:
+        api.clear_notifications(app, user)
+        print_out("<green>Cleared notifications</green>")
+        return
+
     width = 100
     for notification in sorted(api.get_notifications(app, user),
                                key=lambda n: datetime.strptime(

--- a/toot/console.py
+++ b/toot/console.py
@@ -170,7 +170,13 @@ READ_COMMANDS = [
     Command(
         name="notifications",
         description="Notifications for logged in user",
-        arguments=[],
+        arguments=[
+            (["--clear"], {
+                "help": "delete all notifications from the server",
+                "action": 'store_true',
+                "default": False,
+            }),
+        ],
         require_auth=True,
     ),
     Command(

--- a/toot/console.py
+++ b/toot/console.py
@@ -168,6 +168,12 @@ READ_COMMANDS = [
         require_auth=True,
     ),
     Command(
+        name="notifications",
+        description="Notifications for logged in user",
+        arguments=[],
+        require_auth=True,
+    ),
+    Command(
         name="instance",
         description="Display instance details",
         arguments=[


### PR DESCRIPTION
Adding support for handling notifications using a "notifications" command.

By default, it will list notifications for current user, most recent first. The list will also contain any status involved in the notification (e.g. for "reblog" or "favourite" notification type), perhaps this is a bit too verbose?

With a `--clear` flag, the command will clear user's notification from the server.