### PR TITLE
Compose / reply functionality in curses interface

### DIFF
--- a/toot/ui/app.py
+++ b/toot/ui/app.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import webbrowser
+import os
 
 from toot import __version__, api
 
@@ -360,7 +361,7 @@ class EntryModal(Modal):
         self.window.erase()
         self.window.box()
 
-        draw_lines(self.window, ["{}  (^G to confirm):".format(self.title)], 1, 2, Color.WHITE)
+        draw_lines(self.window, ["{}  (Ctrl+Enter to confirm):".format(self.title)], 1, 2, Color.WHITE)
         if self.footer:
             window_height, window_width = self.window.getmaxyx()
             draw_lines(self.window, [self.footer], window_height - self.pad_y + 1, 2, Color.WHITE)
@@ -399,11 +400,11 @@ class EntryModal(Modal):
             if self.cursor_pos + 1 <= len(self.content):
                 self.cursor_pos += 1
 
-        elif ch == curses.ascii.ctrl(ord('q')):
-            self.content = []
+        elif ch in (curses.ascii.RS, curses.ascii.EOT):
             return False
 
-        elif ch == curses.ascii.ctrl(ord('g')):
+        elif ch == curses.ascii.ESC:
+            self.content = []
             return False
 
         self.draw()
@@ -423,7 +424,7 @@ class EntryModal(Modal):
 
 class ComposeModal(EntryModal):
     def __init__(self, stdscr, default_cw=None):
-        super().__init__(stdscr, title="Compose a toot", footer="^G to submit, ^Q to quit, ^S to mark sensitive (cw)")
+        super().__init__(stdscr, title="Compose a toot", footer="Ctrl+Enter to submit, ESC to quit, ^S to mark sensitive (cw)")
         self.cw = default_cw
         self.cwmodal = EntryModal(stdscr, title="Content warning", size=(1, 60), default=self.cw)
 
@@ -449,6 +450,7 @@ class TimelineApp:
         self.stdscr = None
 
     def run(self):
+        os.environ.setdefault('ESCDELAY', '25')
         curses.wrapper(self._wrapped_run)
 
     def _wrapped_run(self, stdscr):

--- a/toot/ui/app.py
+++ b/toot/ui/app.py
@@ -308,6 +308,7 @@ class HelpModal(Modal):
             "  b      - toggle boost status",
             "  f      - toggle favourite status",
             "  c      - compose and post a new status",
+            "  r      - compose and reply to status",
             "  q      - quit application",
             "  s      - show sensitive content"
             "",
@@ -473,6 +474,9 @@ class TimelineApp:
             elif key.lower() == 'c':
                 self.compose()
 
+            elif key.lower() == 'r':
+                self.reply()
+
             elif key == 'KEY_RESIZE':
                 self.setup_windows()
                 self.full_redraw()
@@ -502,6 +506,27 @@ class TimelineApp:
         self.footer.draw_message("Submitting status...", Color.YELLOW)
         response = api.post_status(app, user, content, spoiler_text=cw)
         self.footer.draw_message("✓ Status posted", Color.GREEN)
+
+    def reply(self):
+        """Reply to the selected status"""
+        status = self.get_selected_status()
+        app, user = self.app, self.user
+        if not app or not user:
+            self.footer.draw_message("You must be logged in to reply", Color.RED)
+            return
+
+        compose_modal = ComposeModal(self.stdscr)
+        content, cw = compose_modal.loop()
+        self.full_redraw()
+        if content is None:
+            return
+        elif len(content) == 0:
+            self.footer.draw_message("Status must contain content", Color.RED)
+            return
+
+        self.footer.draw_message("Submitting reply...", Color.YELLOW)
+        response = api.post_status(app, user, content, spoiler_text=cw, in_reply_to_id=status['id'])
+        self.footer.draw_message("✓ Reply posted", Color.GREEN)
 
     def toggle_reblog(self):
         """Reblog or unreblog selected status."""

--- a/toot/ui/app.py
+++ b/toot/ui/app.py
@@ -318,7 +318,7 @@ class HelpModal(Modal):
         ]
 
 
-class TextModal(Modal):
+class EntryModal(Modal):
     def __init__(self, stdscr, title, footer=None, size=(None, None)):
         self.content = []
         self.cursor_pos = 0
@@ -333,8 +333,8 @@ class TextModal(Modal):
         height, width, y, x = self.get_size_pos(stdscr)
 
         self.window = curses.newwin(height, width, y, x)
-        self.text_window = self.window.derwin(height - (self.pad_y * 2), width - (self.pad_x * 2 + 1), self.pad_y, self.pad_x)
-        self.text_window.keypad(1)
+        self.text_window = self.window.derwin(height - (self.pad_y * 2), width - (self.pad_x * 2), self.pad_y, self.pad_x)
+        self.text_window.keypad(True)
 
         self.draw()
         self.panel = curses.panel.new_panel(self.window)
@@ -347,7 +347,7 @@ class TextModal(Modal):
         else:
             height = int(screen_height / 1.33)
         if self.size[1]:
-            width = self.size[1] + (self.pad_x * 2 + 1) + 1
+            width = self.size[1] + (self.pad_x * 2) + 1
         else:
             width = int(screen_width / 1.25)
 
@@ -391,11 +391,6 @@ class TextModal(Modal):
             if self.cursor_pos >= 0 and self.cursor_pos < len(self.content):
                 del self.content[self.cursor_pos]
 
-        elif ch == curses.KEY_DC:
-            if self.cursor_pos > 0 and self.cursor_pos <= len(self.content):
-                del self.content[self.cursor_pos - 1]
-                self.cursor_pos -= 1
-
         elif ch == curses.KEY_LEFT:
             if self.cursor_pos > 0:
                 self.cursor_pos -= 1
@@ -423,18 +418,19 @@ class TextModal(Modal):
             if not self.do_command(ch):
                 break
         self.hide()
-        return ''.join(self.content) if len(self.content) > 0 else None
+        return ''.join(self.content)
 
 
-class ComposeModal(TextModal):
+class ComposeModal(EntryModal):
     def __init__(self, stdscr):
         super().__init__(stdscr, title="Compose a toot", footer="^G to submit, ^Q to quit, ^S to mark sensitive (cw)")
         self.cw = None
-        self.cwmodal = TextModal(stdscr, title="Content warning", size=(1, 60))
+        self.cwmodal = EntryModal(stdscr, title="Content warning", size=(1, 60))
 
     def do_command(self, ch):
         if ch == curses.ascii.ctrl(ord('s')):
-            self.cw = self.cwmodal.loop()
+            self.cw = self.cwmodal.loop() or None
+            self.draw()
             return True
         else:
             return super().do_command(ch)

--- a/toot/ui/app.py
+++ b/toot/ui/app.py
@@ -361,7 +361,7 @@ class EntryModal(Modal):
         self.window.erase()
         self.window.box()
 
-        draw_lines(self.window, ["{}  (Ctrl+Enter to confirm):".format(self.title)], 1, 2, Color.WHITE)
+        draw_lines(self.window, ["{}  (^D to confirm):".format(self.title)], 1, 2, Color.WHITE)
         if self.footer:
             window_height, window_width = self.window.getmaxyx()
             draw_lines(self.window, [self.footer], window_height - self.pad_y + 1, 2, Color.WHITE)
@@ -421,7 +421,7 @@ class EntryModal(Modal):
             else:
                 curses.beep()
 
-        elif ch in (curses.ascii.RS, curses.ascii.EOT):
+        elif ch in (curses.ascii.EOT, curses.ascii.RS):  # ^D or (for some terminals) Ctrl+Enter
             return False, False
 
         elif ch == curses.ascii.ESC:
@@ -452,7 +452,7 @@ class EntryModal(Modal):
 
 class ComposeModal(EntryModal):
     def __init__(self, stdscr, default_cw=None):
-        super().__init__(stdscr, title="Compose a toot", footer="Ctrl+Enter to submit, ESC to quit, ^S to mark sensitive (cw)")
+        super().__init__(stdscr, title="Compose a toot", footer="^D to submit, ESC to quit, ^S to mark sensitive (cw)")
         self.cw = default_cw
         self.cwmodal = EntryModal(stdscr, title="Content warning", size=(1, 60), default=self.cw)
 

--- a/toot/ui/app.py
+++ b/toot/ui/app.py
@@ -307,8 +307,8 @@ class HelpModal(Modal):
             "  v      - view current toot in browser",
             "  b      - toggle boost status",
             "  f      - toggle favourite status",
-            "  c      - compose and post a new status",
-            "  r      - compose and reply to status",
+            "  c      - post a new status",
+            "  r      - reply to status",
             "  q      - quit application",
             "  s      - show sensitive content"
             "",

--- a/toot/ui/app.py
+++ b/toot/ui/app.py
@@ -575,6 +575,10 @@ class TimelineApp:
 
         self.footer.draw_message("Submitting status...", Color.YELLOW)
         response = api.post_status(app, user, content, spoiler_text=cw, sensitive=cw is not None)
+        status = parse_status(response)
+        self.statuses.insert(0, status)
+        self.selected += 1
+        self.left.draw_statuses(self.statuses, self.selected)
         self.footer.draw_message("✓ Status posted", Color.GREEN)
 
     def reply(self):
@@ -596,6 +600,10 @@ class TimelineApp:
 
         self.footer.draw_message("Submitting reply...", Color.YELLOW)
         response = api.post_status(app, user, content, spoiler_text=cw, sensitive=cw is not None, in_reply_to_id=status['id'])
+        status = parse_status(response)
+        self.statuses.insert(0, status)
+        self.selected += 1
+        self.left.draw_statuses(self.statuses, self.selected)
         self.footer.draw_message("✓ Reply posted", Color.GREEN)
 
     def toggle_reblog(self):

--- a/toot/ui/utils.py
+++ b/toot/ui/utils.py
@@ -46,6 +46,17 @@ def highlight_hashtags(window, y, padding, line):
         window.chgat(y, start + padding, end - start, Color.HASHTAG)
 
 
+def size_as_drawn(lines, screen_width):
+    """Get the bottom-right corner of some text as would be drawn by draw_lines"""
+    y = 0
+    x = 0
+    for line in lines:
+        for wrapped_line in wc_wrap(line, screen_width):
+            x = len(wrapped_line)
+            y += 1
+    return y - 1, x - 1
+
+
 def draw_lines(window, lines, start_y, padding, default_color):
     height, width = window.getmaxyx()
     text_width = width - 2 * padding

--- a/toot/ui/utils.py
+++ b/toot/ui/utils.py
@@ -51,10 +51,15 @@ def size_as_drawn(lines, screen_width):
     y = 0
     x = 0
     for line in lines:
-        for wrapped_line in wc_wrap(line, screen_width):
-            x = len(wrapped_line)
+        wrapped = list(wc_wrap(line, screen_width))
+        if len(wrapped) > 0:
+            for wrapped_line in wrapped:
+                x = len(wrapped_line)
+                y += 1
+        else:
+            x = 0
             y += 1
-    return y - 1, x - 1
+    return y - 1, x - 1 if x != 0 else 0
 
 
 def draw_lines(window, lines, start_y, padding, default_color):


### PR DESCRIPTION
Add a reply (r) and compose (c) action for the curses interface complete with adding a cw (^s)
Uses the regular draw_lines to draw the textbox, EOT or Ctrl+Enter (not well supported on all terminals) to confirm / post, and updates the timeline with the new status.

The use of draw_lines means that linebreaks due to width work, but strip whitespace down to one character on the display despite them still being included in the text to be sent, which is a tad confusing at first. I'm also working on an [improvement ](https://github.com/Skehmatics/toot/tree/feature/preserve_whitespace) to the fit_text / wc_wrap function that treats whitespace a little more intelligently throughout the interface, but there's a lot of tiny issues I want to work out on that first so it's not included here.

Let me know if you have any concerns or want this all squashed to one commit :)