### PR TITLE
Make "view" action work for reblogged statuses

### DIFF
--- a/toot/tui/entities.py
+++ b/toot/tui/entities.py
@@ -22,6 +22,7 @@ class Status:
     """
     def __init__(self, data, instance):
         self.data = data
+        reblog = data.get('reblog', {})
         self.instance = instance
 
         # This can be toggled by the user
@@ -37,6 +38,7 @@ class Status:
         self.favourited = data.get("favourited", False)
         self.reblogged = data.get("reblogged", False)
         self.in_reply_to = data.get("in_reply_to_id")
+        self.url = reblog.get("url") if reblog else data.get("url")
 
     def get_account(self):
         acct = self.data['account']['acct']

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -140,8 +140,8 @@ class Timeline(urwid.Columns):
             return
 
         if key in ("v", "V"):
-            if status.data["url"]:
-                webbrowser.open(status.data["url"])
+            if status.url:
+                webbrowser.open(status.url)
             return
 
         return super().keypress(size, key)


### PR DESCRIPTION
When the status is a reblog, the URL of the original toot should be used
as the one of the reblog is null.

We add a "url" attribute to Status class storing computed URL.