### PR TITLE
Escape closes timeline

### DIFF
--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -121,6 +121,10 @@ class Timeline(urwid.Columns):
         if key in ("q", "Q"):
             self._emit("close")
             return
+        
+        if key == "esc":
+            self._emit("close")
+            return
 
         if key in ("r", "R"):
             self._emit("reply", status)


### PR DESCRIPTION
The help message says that you can use Esc and Q to go back and close overlays. So it seems logical that you should be able to use Esc to go back when viewing a thread.