### PR TITLE
Try to use media's text_url if present

### DIFF
--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -238,7 +238,8 @@ class StatusDetails(urwid.Pile):
                 yield ("pack", urwid.Text([("bold", "Media attachment"), " (", m["type"], ")"]))
                 if m["description"]:
                     yield ("pack", urwid.Text(m["description"]))
-                yield ("pack", urwid.Text(("link", m["url"])))
+                url = m.get("text_url") or m["url"]
+                yield ("pack", urwid.Text(("link", url)))
 
         poll = status.data.get("poll")
         if poll:


### PR DESCRIPTION
This field is sometimes provides and gives a shortened URL which is
easier to click on in a terminal.