### PR TITLE
Include mentions and replied-to account in compose text

### DIFF
--- a/toot/tui/compose.py
+++ b/toot/tui/compose.py
@@ -14,7 +14,15 @@ class StatusComposer(urwid.Frame):
 
     def __init__(self, in_reply_to=None):
         self.in_reply_to = in_reply_to
-        self.content_edit = EditBox(multiline=True, allow_tab=True)
+        text, edit_pos = '', None
+        if in_reply_to is not None:
+            text = f'@{in_reply_to.account} '
+            edit_pos = len(text)
+            mentions = [f'@{m["acct"]}' for m in in_reply_to.mentions]
+            if mentions:
+                text += '\n\n{}'.format(' '.join(mentions))
+        self.content_edit = EditBox(edit_text=text, edit_pos=edit_pos,
+                                    multiline=True, allow_tab=True)
 
         self.cw_edit = None
         self.cw_add_button = Button("Add content warning",

--- a/toot/tui/entities.py
+++ b/toot/tui/entities.py
@@ -34,6 +34,8 @@ class Status:
         self.reblog = reblog = data.get("reblog")
         self.url = reblog.get("url") if reblog else data.get("url")
 
+        self.mentions = data["mentions"]
+
     def get_author(self):
         # Show the author, not the persopn who reblogged
         data = self.data["reblog"] or self.data


### PR DESCRIPTION
We add a "mentions" attribute to Status. Then when composing a reply, we
fill the edit text of the compose box with the account name of status
being replied to and possibly include mentions at the bottom of the edit
text. Initial cursor position is set after replied account name.