### PR TITLE
Set urwid global encoding to UTF-8

### DIFF
--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -14,6 +14,8 @@ from .utils import show_media
 
 logger = logging.getLogger(__name__)
 
+urwid.set_encoding('UTF-8')
+
 
 class Header(urwid.WidgetWrap):
     def __init__(self, app, user):


### PR DESCRIPTION
so that many characters can be displayed correctly.

before applying this change:
![image](https://user-images.githubusercontent.com/775611/64897399-9461ad80-d683-11e9-99b4-6df778dfdd94.png)

after applying this change:
![image](https://user-images.githubusercontent.com/775611/64897462-c541e280-d683-11e9-81c6-e07390d2d76a.png)
