### PR TITLE
Improve handling of reblogs in TUI 

### DIFF
--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -335,7 +335,7 @@ class TUI(urwid.Frame):
         promise.add_done_callback(lambda *args: self.close_overlay())
 
     def show_media(self, status):
-        urls = [m["url"] for m in status.data["media_attachments"]]
+        urls = [m["url"] for m in status.media_attachments]
         if urls:
             show_media(urls)
 

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -224,7 +224,8 @@ class TUI(urwid.Frame):
 
         # This is pretty fast, so it's probably ok to block while context is
         # loaded, can be made async later if needed
-        context = api.context(self.app, self.user, status.id)
+        status_id = status.reblog["id"] if status.reblog else status.id
+        context = api.context(self.app, self.user, status_id)
         ancestors = [self.make_status(s) for s in context["ancestors"]]
         descendants = [self.make_status(s) for s in context["descendants"]]
         statuses = ancestors + [status] + descendants

--- a/toot/tui/entities.py
+++ b/toot/tui/entities.py
@@ -33,6 +33,10 @@ class Status:
 
         self.reblog = reblog = data.get("reblog")
         self.url = reblog.get("url") if reblog else data.get("url")
+        self.media_attachments = (
+            reblog["media_attachments"]
+            if reblog else data["media_attachments"]
+        )
 
     def get_author(self):
         # Show the author, not the persopn who reblogged

--- a/toot/tui/entities.py
+++ b/toot/tui/entities.py
@@ -37,6 +37,18 @@ class Status:
             reblog["media_attachments"]
             if reblog else data["media_attachments"]
         )
+        self.favourites_count = (
+            reblog["favourites_count"]
+            if reblog else data["favourites_count"]
+        )
+        self.replies_count = (
+            reblog["replies_count"]
+            if reblog else data["replies_count"]
+        )
+        self.reblogs_count = (
+            reblog["reblogs_count"]
+            if reblog else data["reblogs_count"]
+        )
 
     def get_author(self):
         # Show the author, not the persopn who reblogged

--- a/toot/tui/entities.py
+++ b/toot/tui/entities.py
@@ -29,9 +29,11 @@ class Status:
         self.author = self.get_author()
         self.favourited = data.get("favourited", False)
         self.reblogged = data.get("reblogged", False)
-        self.in_reply_to = data.get("in_reply_to_id")
-
         self.reblog = reblog = data.get("reblog")
+        self.in_reply_to = (
+            reblog.get("in_reply_to_id")
+            if reblog else data.get("in_reply_to_id")
+        )
         self.url = reblog.get("url") if reblog else data.get("url")
         self.media_attachments = (
             reblog["media_attachments"]

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -231,7 +231,7 @@ class StatusDetails(urwid.Pile):
             for line in format_content(status.data["content"]):
                 yield ("pack", urwid.Text(highlight_hashtags(line)))
 
-        media = status.data["media_attachments"]
+        media = status.media_attachments
         if media:
             for m in media:
                 yield ("pack", urwid.AttrMap(urwid.Divider("-"), "gray"))

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -256,9 +256,9 @@ class StatusDetails(urwid.Pile):
 
         yield ("pack", urwid.AttrWrap(urwid.Divider("-"), "gray"))
         yield ("pack", urwid.Text([
-            ("gray", "⤶ {} ".format(status.data["replies_count"])),
-            ("yellow" if status.reblogged else "gray", "♺ {} ".format(status.data["reblogs_count"])),
-            ("yellow" if status.favourited else "gray", "★ {}".format(status.data["favourites_count"])),
+            ("gray", "⤶ {} ".format(status.replies_count)),
+            ("yellow" if status.reblogged else "gray", "♺ {} ".format(status.reblogs_count)),
+            ("yellow" if status.favourited else "gray", "★ {}".format(status.favourites_count)),
             ("gray", " · {}".format(application) if application else ""),
         ]))
 

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -209,7 +209,7 @@ class StatusDetails(urwid.Pile):
         return super().__init__(widget_list)
 
     def content_generator(self, status):
-        if status.data["reblog"]:
+        if status.reblog:
             boosted_by = status.data["account"]["display_name"]
             yield ("pack", urwid.Text(("gray", "♺ {} boosted".format(boosted_by))))
             yield ("pack", urwid.AttrMap(urwid.Divider("-"), "gray"))


### PR DESCRIPTION
A couple of changes to improve handling of reblogs in the urwid TUI, mostly to retrieve data from the original status (the one that's reblogged) instead of from the reblog.