### PR TITLE
Fall back to "username" when "display_name" is unset

### DIFF
--- a/toot/tui/entities.py
+++ b/toot/tui/entities.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 from .utils import parse_datetime
 
-Author = namedtuple("Author", ["account", "display_name"])
+Author = namedtuple("Author", ["account", "display_name", "username"])
 
 
 class Status:
@@ -73,7 +73,7 @@ class Status:
     def _get_author(self):
         acct = self.data['account']['acct']
         acct = acct if "@" in acct else "{}@{}".format(acct, self.default_instance)
-        return Author(acct, self.data['account']['display_name'])
+        return Author(acct, self.data['account']['display_name'], self.data['account']['username'])
 
     def _get_account(self):
         acct = self.data['account']['acct']

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -220,7 +220,7 @@ class StatusDetails(urwid.Pile):
 
     def content_generator(self, status, reblogged_by):
         if reblogged_by:
-            text = "♺ {} boosted".format(reblogged_by.display_name)
+            text = "♺ {} boosted".format(reblogged_by.display_name or reblogged_by.username)
             yield ("pack", urwid.Text(("gray", text)))
             yield ("pack", urwid.AttrMap(urwid.Divider("-"), "gray"))
 


### PR DESCRIPTION
We add a "username" field to Author entity, this is then used when
displaying the "reblogged by" information when respective account has no
display name.