### PR TITLE
Fix VISIBILITY_OPTIONS

### DIFF
--- a/toot/tui/constants.py
+++ b/toot/tui/constants.py
@@ -39,7 +39,7 @@ PALETTE = [
 
 VISIBILITY_OPTIONS = [
     ("public", "Public", "Post to public timelines"),
-    ("private", "Private", "Do not post to public timelines"),
-    ("unlisted", "Unlisted", "Post to followers only"),
+    ("unlisted", "Unlisted", "Do not post to public timelines"),
+    ("private", "Private", "Post to followers only"),
     ("direct", "Direct", "Post to mentioned users only"),
 ]


### PR DESCRIPTION
Reorder Visibility Options to be from "most visible" to "least visible", and swap the definitions of "private" and "unlisted" to match the actual visibility that results from those actions.

Fixes #152 