### PR TITLE
Add homebrew instructions to install docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -103,6 +103,17 @@ Install from PyPI using pip, preferably into a virtual environment.
 
     pip install --user toot
 
+Homebrew
+--------------------
+
+This works on Mac OSX with `homebrew <https://brew.sh/>`_ installed.
+Tested with on Catalina, Mojave, and High Sierra.
+
+.. code-block:: bash
+
+    brew update
+    brew install toot
+
 Source
 ------
 


### PR DESCRIPTION
Hello @ihabunek big fan of this project! Recently added it to homebrew so mac users have an easy install method. I see [repology.org](https://repology.org/project/toot/versions) has already picked up the change. 

Homebrew formula: https://github.com/Homebrew/homebrew-core/blob/master/Formula/toot.rb

I've subscribed to notifications on this repo and I'll update homebrew when new versions come. 