### PR TITLE
TUI: Use original toot for replies and thread

### DIFF
--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -144,7 +144,7 @@ class Timeline(urwid.Columns):
             return
 
         if key in ("r", "R"):
-            self._emit("reply", status)
+            self._emit("reply", status.original)
             return
 
         if key in ("s", "S"):
@@ -157,7 +157,7 @@ class Timeline(urwid.Columns):
             return
 
         if key in ("t", "T"):
-            self._emit("thread", status)
+            self._emit("thread", status.original)
             return
 
         if key in ("u", "U"):


### PR DESCRIPTION
Previously if you tried to reply to a boosted toot, the username automatically put in the reply box was the username of the one who boosted it, rather than the one who originally posted it. 

Also, when you opened a boosted thread, it would go to the boosted thread, rather than the original thread.

This fixes both of those issues by using the original
toot for both replies and threads.