### PR TITLE
login_cli: add TOOT_LOGIN_CLI_PASSWORD env variable

### DIFF
--- a/toot/auth.py
+++ b/toot/auth.py
@@ -57,7 +57,7 @@ def create_user(app, access_token):
     return user
 
 
-def login_interactive(app, email=None):
+def login_interactive(app, email=None, password=None):
     print_out("Log in to <green>{}</green>".format(app.instance))
 
     if email:
@@ -66,7 +66,8 @@ def login_interactive(app, email=None):
     while not email:
         email = input('Email: ')
 
-    password = getpass('Password: ')
+    if not password:
+        password = getpass('Password: ')
 
     try:
         print_out("Authenticating...")

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
+import os
 
 from toot import api, config
 from toot.auth import login_interactive, login_browser_interactive, create_app_interactive
@@ -179,7 +180,8 @@ def auth(app, user, args):
 
 def login_cli(app, user, args):
     app = create_app_interactive(instance=args.instance, scheme=args.scheme)
-    login_interactive(app, args.email)
+    password = os.getenv('TOOT_LOGIN_CLI_PASSWORD', None)
+    login_interactive(app, args.email, password)
 
     print_out()
     print_out("<green>✓ Successfully logged in.</green>")


### PR DESCRIPTION
Hi,

toot is currently using the `getpass` library to prevent a user to feed a password to the login_cli command.

While it's a really good default and will prevent a lot of people from doing something stupid, it's preventing me from using toot in a NixOS VM integration test.

We are using these VM integration tests to automatically check we did not break a packages or a module after an update. These tests are running in a non-interactive fashion on our CI.

I'm using toot to test the (new!) pleroma module we're about to provide https://github.com/NinjaTrappeur/nixpkgs/blob/nin-pleroma/nixos/tests/pleroma.nix#L27 https://github.com/NinjaTrappeur/nixpkgs/blob/nin-pleroma/nixos/tests/pleroma.nix#L177.

Without a way to inject a password to `login_cli`, there's no way for me to login to the pleroma instance without using a really ugly dirty hack (curl-ing a oauth token and sed-butchering toot's config).

I admit this use case is **really** niche. But I'm also pretty sure there are other use case for running toot in a non-interactive environment.

This PR is basically provides an escape hatch for such a workflow. I intentionally do not advertise this env variable anywhere except in the source code (and now this PR...): the power users will find it from the source code and will have a way to do what they want without providing a footgun to the regular users.

WDYT?

```
login_cli is currently using getpass to interactively retrieve a
password from the terminal. This library is intentionally preventing a
user to provide a password from a non interactive script.

There are however some legitimate cases when you want to non
interactively log in using toot, such as a NixOS VM test.

We now read a potential password from the TOOT_LOGIN_CLI_PASSWORD env
variable then fallback to the getpass interactive style.

We do not document this feature intentionally. It'll prevent most
users from using a footgun while providing advanced users with a
escape hatch.
```