### PR TITLE
WIP: Prevent toot timeline to break when piped to extenal programs

### DIFF
--- a/toot/commands.py
+++ b/toot/commands.py
@@ -52,7 +52,7 @@ def timeline(app, user, args):
 
         print_timeline(items)
 
-        if args.once:
+        if args.once or sys.stdin.isatty():
             break
 
         char = input("\nContinue? [Y/n] ")


### PR DESCRIPTION
Toot timeline try to ask the user to continue in the next page. This
dont works if the command is piped to any other software.

We stop the query in the first loop when not in a tty context. The
command should be called with the expected item count in this case.