### PR TITLE
Update of FreeBSD package name

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -55,7 +55,7 @@ Install the package:
 
 .. code-block:: bash
 
-    pkg install py36-toot
+    pkg install py38-toot
 
 Build and install from sources:
 


### PR DESCRIPTION
The package in FreeBSD is now py38-toot, and not py36-toot.