### PR TITLE
WIP alt text for uploaded media

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -92,6 +92,7 @@ def post_status(
     spoiler_text=None,
     in_reply_to_id=None,
     language=None,
+    description=None,
 ):
     """
     Posts a new status.
@@ -110,6 +111,7 @@ def post_status(
         'spoiler_text': spoiler_text,
         'in_reply_to_id': in_reply_to_id,
         'language': language,
+        'description': description,
     }, headers=headers).json()
 
 
@@ -215,9 +217,21 @@ def anon_tag_timeline_generator(instance, hashtag, local=False, limit=20):
     return _anon_timeline_generator(instance, path, params)
 
 
-def upload_media(app, user, file):
+def upload_media(app, user, file, description=None):
+    # this print confirms that the 'description' argument is being supplied correctly
+    # when toot is invoked like:
+    # toot post --description "a cute fluffy animal" --media cute-animal.png
+    print('upload_media:', '"', description, '"')
+    # however, when actually supplied below, the mastodon web UI displays
+    # the following for the 'alt' and 'title' attributes:
+    # "#<ActionDispatch::Http::UploadedFile:0x00007fa2aff698d0>"
+
+    # I also tried supplying http.post with a named data argument
+    # data={ 'description': description }
+    # but that seems to have no effect
     return http.post(app, user, '/api/v1/media', files={
-        'file': file
+        'file': file,
+        'description': description,
     }).json()
 
 

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -88,7 +88,7 @@ def post(app, user, args):
         args.text = sys.stdin.read().rstrip()
 
     if args.media:
-        media = [_do_upload(app, user, file) for file in args.media]
+        media = [_do_upload(app, user, file, description=args.description) for file in args.media]
         media_ids = [m["id"] for m in media]
     else:
         media = None
@@ -114,6 +114,7 @@ def post(app, user, args):
         spoiler_text=args.spoiler_text,
         in_reply_to_id=args.reply_to,
         language=args.language,
+        description=args.description,
     )
 
     print_out("Toot posted: <green>{}</green>".format(response.get('url')))
@@ -222,9 +223,9 @@ def search(app, user, args):
     print_search_results(response)
 
 
-def _do_upload(app, user, file):
+def _do_upload(app, user, file, description=None):
     print_out("Uploading media: <green>{}</green>".format(file.name))
-    return api.upload_media(app, user, file)
+    return api.upload_media(app, user, file, description=description)
 
 
 def _find_account(app, user, account_name):

--- a/toot/console.py
+++ b/toot/console.py
@@ -297,6 +297,10 @@ POST_COMMANDS = [
                 "help": "path to the media file to attach (specify multiple "
                         "times to attach up to 4 files)"
             }),
+            (["-d", "--description"], {
+                "type": str,
+                "help": 'A plain-text description of the media, for accessibility purposes.'
+            }),
             (["-v", "--visibility"], {
                 "type": visibility,
                 "default": "public",


### PR DESCRIPTION
Hi!

I recently set up my own Mastodon instance and wanted to experiment with automating some posts. I looked around and `toot` seemed to be the simplest way to get started. I found it really easy to use, so thanks for this awesome project!

I read through [toot's documentation](https://toot.readthedocs.io/en/latest/usage.html) and its code, but didn't see any way to add alt-text to uploaded media. I also read some of [the Mastodon API documentation](https://docs.joinmastodon.org/methods/statuses/media/) and found that it accepts a "description" attribute. This PR is my incomplete attempt at adding support for it.

I was able to add a `--description` command and verify that it was interpreted correctly by the command line argument parser. After that I sort of fumbled through the code and added named `description` arguments anywhere it looked like it might help.

After a little experimentation I managed to get _something_ to go through to my Mastodon server, however, instead of the supplied description (a string, which I confirmed with a `print` call) what seems to be an internal value from the `Requests` library (`"#<ActionDispatch::Http::UploadedFile:0x00007fa2aff698d0>"`) is displayed in the Mastodon web client.  This can be seen in [a post that was uploaded in this manner](https://social.cryptography.dog/@bot/106823134553346363) with `toot post --description "a cute fluffy animal" --media cute-animal.png`.

I am not an expert with Python, so I'm hoping this is from a trivial mistake on my part. I'm stuck as to how to investigate further, so I'm just sharing my current progress in the hope that a maintainer or another contributor finds it useful.

Thanks again for this very fun and useful tool!