### PR TITLE
[Z]oom command that opens status in scrollable popup window

### DIFF
--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -8,7 +8,7 @@ from toot import api, config, __version__
 from .compose import StatusComposer
 from .constants import PALETTE
 from .entities import Status
-from .overlays import ExceptionStackTrace, GotoMenu, Help, StatusSource, StatusLinks
+from .overlays import ExceptionStackTrace, GotoMenu, Help, StatusSource, StatusLinks, StatusZoom
 from .overlays import StatusDeleteConfirmation
 from .timeline import Timeline
 from .utils import parse_content_links, show_media
@@ -192,6 +192,9 @@ class TUI(urwid.Frame):
         def _menu(timeline, status):
             self.show_context_menu(status)
 
+        def _zoom(timeline, status_details):
+            self.show_status_zoom(status_details)
+
         urwid.connect_signal(timeline, "compose", _compose)
         urwid.connect_signal(timeline, "delete", _delete)
         urwid.connect_signal(timeline, "favourite", self.async_toggle_favourite)
@@ -202,6 +205,7 @@ class TUI(urwid.Frame):
         urwid.connect_signal(timeline, "reply", _reply)
         urwid.connect_signal(timeline, "source", _source)
         urwid.connect_signal(timeline, "links", _links)
+        urwid.connect_signal(timeline, "zoom", _zoom)
 
     def build_timeline(self, name, statuses, local):
         def _close(*args):
@@ -331,6 +335,12 @@ class TUI(urwid.Frame):
                 title="Status links",
                 options={"height": len(links) + 2},
             )
+
+    def show_status_zoom(self, status_details):
+        self.open_overlay(
+            widget=StatusZoom(status_details),
+            title="Status zoom",
+        )
 
     def show_exception(self, exception):
         self.open_overlay(

--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -20,6 +20,14 @@ class StatusSource(urwid.ListBox):
         super().__init__(walker)
 
 
+class StatusZoom(urwid.ListBox):
+    """Opens status in scrollable popup window"""
+    def __init__(self, status_details):
+        ll = list(filter(lambda x: getattr(x, "rows", None), status_details.widget_list))
+        walker = urwid.SimpleFocusListWalker(ll)
+        super().__init__(walker)
+
+
 class StatusLinks(urwid.ListBox):
     """Shows status links."""
 
@@ -161,6 +169,7 @@ class Help(urwid.Padding):
         yield urwid.Text(h("  [L] - Show the status links"))
         yield urwid.Text(h("  [U] - Show the status data in JSON as received from the server"))
         yield urwid.Text(h("  [V] - Open status in default browser"))
+        yield urwid.Text(h("  [Z] - Open status in scrollable popup window"))
         yield urwid.Divider()
         yield urwid.Text(("bold", "Links"))
         yield urwid.Divider()

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -29,6 +29,7 @@ class Timeline(urwid.Columns):
         "links",      # Show status links
         "thread",     # Show thread for status
         "save",       # Save current timeline
+        "zoom",       # Open status in scrollable popup window
     ]
 
     def __init__(self, name, statuses, focus=0, is_thread=False):
@@ -173,6 +174,10 @@ class Timeline(urwid.Columns):
             self._emit("save", status)
             return
 
+        if key in ("z", "Z"):
+            self._emit("zoom", self.status_details)
+            return
+
         return super().keypress(size, key)
 
     def append_status(self, status):
@@ -305,6 +310,7 @@ class StatusDetails(urwid.Pile):
             "[L]inks",
             "[R]eply",
             "So[u]rce",
+            "[Z]oom",
             "[H]elp",
         ]
         options = " ".join(o for o in options if o)


### PR DESCRIPTION
Added a [Z]oom command that opens the current status in a scrollable popup window similar to the window used by the view source command.

This is one way of getting the message scrolling requested in #166.

Here's what it looks like:

![toot-zoom](https://user-images.githubusercontent.com/1270352/136676320-40e0dc3b-b090-4050-97d4-ec12b11ebb9a.png)