### PR TITLE
Show media attachments in the "L" list of links

### DIFF
--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -325,6 +325,11 @@ class TUI(urwid.Frame):
 
     def show_links(self, status):
         links = parse_content_links(status.data["content"]) if status else []
+        post_attachments = status.data["media_attachments"] or []
+        reblog_attachments = (status.data["reblog"]["media_attachments"] if status.data["reblog"] else None) or []
+        for a in post_attachments + reblog_attachments:
+            url = a["remote_url"] or a["url"]
+            links.append((url, a["description"] if a["description"] else url))
         if links:
             self.open_overlay(
                 widget=StatusLinks(links),


### PR DESCRIPTION
Current behavior: the "L" command shows list of URLs found in the post and lets you choose a link to open in your web browser.

New behavior: The list now includes media attachments too.  Attachments are labeled with their alt-text if present, otherwise the URL is used.

![toot-media](https://user-images.githubusercontent.com/1270352/136676417-c9a8f812-4008-4a09-adb0-ee1a2323a4e4.png)

This lets you pop open media attachments without resorting to "V"iewing the whole post in a browser.