### PR TITLE
Add warning for sensitive (nsfw) posts

### DIFF
--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -259,6 +259,8 @@ class StatusDetails(urwid.Pile):
         if status.data["spoiler_text"] and not status.show_sensitive:
             yield ("pack", urwid.Text(("content_warning", "Marked as sensitive. Press S to view.")))
         else:
+            if status.data["sensitive"] and not status.data["spoiler_text"]:
+                yield ("pack", urwid.Text(("yellow", "- Sensitive/nsfw -")))
             for line in format_content(status.data["content"]):
                 yield ("pack", urwid.Text(highlight_hashtags(line)))
 


### PR DESCRIPTION
Note that this warning is ignored if data["sensitive"] == True but data["spoiler_text"] is non-empty, which is possible when the user writes a post with a spoiler. Figured that would be warning enough.

Of course, am open to formatting suggestions as well.