### PR TITLE
Editor metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,24 @@
 .PHONY: clean publish test docs
 
+PYTHON ?= python
+PYTEST ?= pytest
+PY_TEST ?= py.test
+
 dist :
-	python setup.py sdist --formats=gztar,zip
-	python setup.py bdist_wheel --python-tag=py3
+	$(PYTHON) setup.py sdist --formats=gztar,zip
+	$(PYTHON) setup.py bdist_wheel --python-tag=py3
 
 deb_dist:
-	python setup.py --command-packages=stdeb.command bdist_deb
+	$(PYTHON) setup.py --command-packages=stdeb.command bdist_deb
 
 publish :
 	twine upload dist/*.tar.gz dist/*.whl
 
 test:
-	pytest -v
+	$(PYTEST) -v
 
 coverage:
-	py.test --cov=toot --cov-report html tests/
+	$(PY_TEST) --cov=toot --cov-report html tests/
 
 clean :
 	find . -name "*pyc" | xargs rm -rf $1

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -7,7 +7,7 @@ from toot.auth import login_interactive, login_browser_interactive, create_app_i
 from toot.exceptions import ConsoleError, NotFoundError
 from toot.output import (print_out, print_instance, print_account,
                          print_search_results, print_timeline, print_notifications)
-from toot.utils import assert_domain_exists, editor_input, multiline_input, EOF_KEY
+from toot.utils import assert_domain_exists, parse_editor_input, multiline_input, EOF_KEY
 
 
 def get_timeline_generator(app, user, args):
@@ -76,9 +76,11 @@ def thread(app, user, args):
 
 
 def post(app, user, args):
-    # TODO: this might be achievable, explore options
-    if args.editor and not sys.stdin.isatty():
-        raise ConsoleError("Cannot run editor if not in tty.")
+    if args.editor:
+        # TODO: this might be achievable, explore options
+        if not sys.stdin.isatty():
+            raise ConsoleError("Cannot run editor if not in tty.")
+        args = parse_editor_input(args)
 
     if args.media and len(args.media) > 4:
         raise ConsoleError("Cannot attach more than 4 files.")
@@ -102,9 +104,7 @@ def post(app, user, args):
     if uploaded_media and not args.text:
         args.text = "\n".join(m['text_url'] for m in uploaded_media)
 
-    if args.editor:
-        args.text = editor_input(args.editor, args.text)
-    elif not args.text:
+    if not args.editor and not args.text:
         print_out("Write or paste your toot. Press <yellow>{}</yellow> to post it.".format(EOF_KEY))
         args.text = multiline_input()
 

--- a/toot/console.py
+++ b/toot/console.py
@@ -10,27 +10,7 @@ from collections import namedtuple
 from toot import config, commands, CLIENT_NAME, CLIENT_WEBSITE, __version__
 from toot.exceptions import ApiError, ConsoleError
 from toot.output import print_out, print_err
-
-VISIBILITY_CHOICES = ['public', 'unlisted', 'private', 'direct']
-
-
-def language(value):
-    """Validates the language parameter"""
-    if len(value) != 3:
-        raise ArgumentTypeError(
-            "Invalid language specified: '{}'. Expected a 3 letter "
-            "abbreviation according to ISO 639-2 standard.".format(value)
-        )
-
-    return value
-
-
-def visibility(value):
-    """Validates the visibility parameter"""
-    if value not in VISIBILITY_CHOICES:
-        raise ValueError("Invalid visibility value")
-
-    return value
+from toot.utils import language, visibility, visibility_choices
 
 
 def timeline_count(value):
@@ -306,7 +286,7 @@ POST_COMMANDS = [
             (["-v", "--visibility"], {
                 "type": visibility,
                 "default": "public",
-                "help": 'post visibility, one of: %s' % ", ".join(VISIBILITY_CHOICES),
+                "help": 'post visibility, one of: %s' % visibility_choices(),
             }),
             (["-s", "--sensitive"], {
                 "action": 'store_true',

--- a/toot/utils.py
+++ b/toot/utils.py
@@ -136,16 +136,16 @@ def parse_editor_meta(line, args):
         args.media.append(FileType('rb')(val))
     elif key == 'description':
         args.description.append(val)
-    elif key == 'lang' or key == 'language':
+    elif key in ['lang', 'language']:
         args.language = language(val)
-    elif key == 'spoiler' or key == 'spoiler-text' or key == 'spoiler_text':
+    elif key in ['spoiler', 'spoiler-text', 'spoiler_text']:
         args.spoiler_text = val
-    elif key == 'reply-to' or key == 'reply_to' or key == 'replyto':
+    elif key in ['reply-to', 'reply_to', 'replyto', 'in-reply-to', 'in_reply_to']:
         args.reply_to = val
     elif key == 'visibility':
         args.visibility = visibility(val)
-    elif key == 'sensitive':
-        # 0, f, false, n will count s not-sensitive, any other value will be taken as a yes'
+    elif key in ['sensitive', 'nsfw']:
+        # 0, f, false, n, no will count as not-sensitive, any other value will be taken as a yes
         args.sensitive = val.lower() not in [ '0', 'f', 'false', 'n', 'no' ]
     else:
         print_out("Ignoring unsupported comment metadata <red>{}</red> with value <yellow>{}</yellow>.".format(key, val))

--- a/toot/utils.py
+++ b/toot/utils.py
@@ -12,6 +12,8 @@ from bs4 import BeautifulSoup
 
 from toot.exceptions import ConsoleError
 
+from argparse import FileType
+
 VISIBILITY_CHOICES = ['public', 'unlisted', 'private', 'direct']
 
 def language(value):
@@ -116,7 +118,7 @@ def multiline_input():
 EDITOR_INPUT_INSTRUCTIONS = """
 # Please enter your toot. Lines starting with '#' will be ignored, and an empty
 # message aborts the post.
-# Metadata comments can be set for media, description, lang, spoiler, reply-to, visibility
+# Metadata comments can be set for media, description, lang, spoiler, reply-to, visibility, sensitive
 """
 
 def parse_editor_meta(line, args):
@@ -131,19 +133,20 @@ def parse_editor_meta(line, args):
         return True
     # TODO override user with 'from'
     if key == 'media':
-        args.media = args.media or []
-        args.media.append(val)
+        args.media.append(FileType('rb')(val))
     elif key == 'description':
-        args.description = args.description or []
         args.description.append(val)
     elif key == 'lang' or key == 'language':
         args.language = language(val)
-    elif key == 'spoiler':
+    elif key == 'spoiler' or key == 'spoiler-text' or key == 'spoiler_text':
         args.spoiler_text = val
     elif key == 'reply-to' or key == 'reply_to' or key == 'replyto':
         args.reply_to = val
     elif key == 'visibility':
         args.visibility = visibility(val)
+    elif key == 'sensitive':
+        # 0, f, false, n will count s not-sensitive, any other value will be taken as a yes'
+        args.sensitive = val.lower() not in [ '0', 'f', 'false', 'n', 'no' ]
     else:
         print_out("Ignoring unsupported comment metadata <red>{}</red> with value <yellow>{}</yellow>.".format(key, val))
     return True
@@ -153,8 +156,42 @@ def parse_editor_input(args):
     """Lets user input text using an editor."""
 
     editor = args.editor
-    # TODO initialize metacomments from the args field
-    text = (args.text or "") + EDITOR_INPUT_INSTRUCTIONS
+    # initialize metacomments from the args field, and reset them in args so that
+    # they get reset if removed from the metacomments
+    meta = ""
+    if args.reply_to:
+        meta += "# reply_to: " + args.reply_to + "\n"
+        args.reply_to = None
+    if args.visibility:
+        meta += "# visibility: " + args.visibility + "\n"
+        args.visibility = 'public' # TODO can we take the default from the command definition?
+    if args.language:
+        meta += "# lang: " + args.language + "\n"
+        args.language = None
+    if args.spoiler_text:
+        meta += "# spoiler: " + args.spoiler_text + "\n"
+        args.spoiler_text = None
+    if args.sensitive:
+        meta += "# sensitive: " + args.sensitive + "\n"
+        args.sensitive = False
+
+    media = args.media or []
+    descriptions = args.description or []
+    if len(media) > 0:
+        for idx, file in enumerate(media):
+            meta += "# media: " + file.name + "\n"
+            # encourage the user to add descriptions, always present the meta field
+            desc = descriptions[idx].strip() if idx < len(descriptions) else ''
+            meta += "# description: " + desc + "\n"
+    if len(descriptions) > len(media):
+        for idx, desc in enumerate(descriptions):
+            if idx < len(media):
+                continue
+            meta += "# description: "+ descriptions[idx].strip() + "\n"
+
+    args.media = []
+    args.description = []
+    text = meta + (args.text or "") + EDITOR_INPUT_INSTRUCTIONS
 
     # loop to avoid losing text if something goes wrong (e.g. wrong visibility setting)
     with tempfile.NamedTemporaryFile() as f:
@@ -172,6 +209,11 @@ def parse_editor_input(args):
                 lines = text.strip().splitlines()
                 lines = (l for l in lines if not parse_editor_meta(l, args))
                 args.text = "\n".join(lines)
+
+                # sanity check: this wll be checked by post() too, but we want to catch this early so that
+                # the user can still fix things in the editor
+                if args.media and len(args.media) > 4:
+                    raise ConsoleError("Cannot attach more than 4 files.")
             except Exception as e:
                 text += "\n#" + str(e)
                 continue


### PR DESCRIPTION
This is intended to close #202 by allowing key: value metadata to be added to the toot text in the editor . All command-line options are supported and can be overriden from the editor. Comment support is removed (per IRC conversation) in favor of a YAML-style metadata block (not actual YAML though).