### PR TITLE
Normalise usernames when searching

### DIFF
--- a/toot/commands.py
+++ b/toot/commands.py
@@ -251,7 +251,8 @@ def _find_account(app, user, account_name):
         account_name = account_name[1:]
 
     for account in accounts:
-        if account['acct'] == account_name:
+        # Normalise string matching because usernames are case insensitive
+        if account['acct'].lower() == account_name.lower():
             return account
 
     raise ConsoleError("Account not found")


### PR DESCRIPTION
# What

* Normalise strings by making them both lowercase during comparison

# Why

I found while using the CLI that I couldn't find a number of users despite getting the correct data when I used `--debug`. Usernames on mastodon aren't case sensitive but the string comparison used to find them in the CLI is. Essentially, this PR removes that case sensitivity to make user-based operations a much nicer experience.