### PR TITLE
use /v2 api for account search

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -238,17 +238,11 @@ def search(app, user, query, resolve):
 
 
 def search_accounts(app, user, query):
-    try:
-        return http.get(app, user, '/api/v1/accounts/search', {
-            'q': query,
-        }).json()
-
-    # some servers does not support v1 account search, try v2
-    except NotFoundError:
-        return http.get(app, user, '/api/v2/search', {
-            'q': query,
-            'resolve': True,
-        }).json()['accounts']
+    return http.get(app, user, '/api/v2/search', {
+        'q': query,
+        'type': 'accounts',
+        'resolve': True,
+    }).json()['accounts']
 
 
 def follow(app, user, account):

--- a/toot/api.py
+++ b/toot/api.py
@@ -238,9 +238,17 @@ def search(app, user, query, resolve):
 
 
 def search_accounts(app, user, query):
-    return http.get(app, user, '/api/v1/accounts/search', {
-        'q': query,
-    }).json()
+    try:
+        return http.get(app, user, '/api/v1/accounts/search', {
+            'q': query,
+        }).json()
+
+    # some servers does not support v1 account search, try v2
+    except NotFoundError:
+        return http.get(app, user, '/api/v2/search', {
+            'q': query,
+            'resolve': True,
+        }).json()['accounts']
 
 
 def follow(app, user, account):


### PR DESCRIPTION
Some servers (namely gotosocial) do not support /api/v1/accounts/search. This patch adds fallback to v2 search when 404 is encountered.