### PR TITLE
Added install instructions for fedora linux.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -48,6 +48,17 @@ Install from `AUR <https://aur.archlinux.org/packages/toot/>`_.
 
     yay -S toot
 
+
+Fedora
+-------------
+
+Toot is available from the Fedora package repository.
+
+.. code-block:: bash
+
+    sudo dnf install toot
+
+
 FreeBSD ports
 -------------
 


### PR DESCRIPTION
Installation of toot on fedora is simple and obvious but should be still mentioned in the docs for people newly starting with fedora.