### PR TITLE
Fix typo

### DIFF
--- a/toot/console.py
+++ b/toot/console.py
@@ -443,7 +443,7 @@ ACCOUNTS_COMMANDS = [
     ),
     Command(
         name="following",
-        description="List accounts following the given account",
+        description="List accounts followed by the given account",
         arguments=[
             account_arg,
         ],
@@ -451,7 +451,7 @@ ACCOUNTS_COMMANDS = [
     ),
     Command(
         name="followers",
-        description="List accounts followed by the given account",
+        description="List accounts following the given account",
         arguments=[
             account_arg,
         ],


### PR DESCRIPTION
Correct interchanged help text for `following` and `follows` commands.