### PR TITLE
Add vim modeline to EDITOR_INPUT_INSTRUCTIONS #231

### DIFF
--- a/toot/utils.py
+++ b/toot/utils.py
@@ -99,6 +99,7 @@ EDITOR_INPUT_INSTRUCTIONS = f"""
 Do not modify or remove the line above.
 Enter your toot above it.
 Everything below it will be ignored.
+vim:backupcopy=yes
 """
 
 


### PR DESCRIPTION
To solve #231, there are three options I can think of:

1. Open the temp file again after calling `subprocess.run`, which adds overhead to all other text editors
2. Ask individual vim users to add `set backupcopy=yes` to their vimrc file, which requires every vim users to set backupcopy which isn't default
3. Change vim setting by adding modeline to the EDITOR_INPUT_INSTRUCTIONS, which adds couple more characters to EDITOR_INPUT_INSTRUCTIONS

It seems that option 3 is a middle ground between overhead and user experience, thus this PR.

P.s. Instead of rename the file and write a new one, `backupcopy=yes` forces vim to make a copy of the file and overwrite the original one.