### PR TITLE
Adds translate status feature (when connected to a Mastodon 4.x server with translation enabled)

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -209,6 +209,10 @@ def unbookmark(app, user, status_id):
     return _status_action(app, user, status_id, 'unbookmark')
 
 
+def translate(app, user, status_id):
+    return _status_action(app, user, status_id, 'translate')
+
+
 def context(app, user, status_id):
     url = '/api/v1/statuses/{}/context'.format(status_id)
 

--- a/toot/output.py
+++ b/toot/output.py
@@ -165,7 +165,6 @@ def print_instance(instance):
                 else:
                     print_out(f"{' ' * len(ordinal)} {line}")
 
-
 def print_account(account):
     print_out("<green>@{}</green> {}".format(account['acct'], account['display_name']))
 

--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -164,6 +164,7 @@ class Help(urwid.Padding):
         yield urwid.Text(h("  [B] - Boost/unboost status"))
         yield urwid.Text(h("  [C] - Compose new status"))
         yield urwid.Text(h("  [F] - Favourite/unfavourite status"))
+        yield urwid.Text(h("  [N] - Translate status, if possible"))
         yield urwid.Text(h("  [R] - Reply to current status"))
         yield urwid.Text(h("  [S] - Show text marked as sensitive"))
         yield urwid.Text(h("  [T] - Show status thread (replies)"))

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -164,7 +164,7 @@ class Timeline(urwid.Columns):
                 self._emit("translate", status)
             return
 
-        if key in ("r", "R"):
+        if key in ("t", "T"):
             self._emit("thread", status)
             return
 

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -4,7 +4,7 @@ import webbrowser
 
 from toot.utils import format_content
 
-from .utils import Option, highlight_hashtags, parse_datetime, highlight_keys
+from .utils import highlight_hashtags, parse_datetime, highlight_keys
 from .widgets import SelectableText, SelectableColumns
 
 logger = logging.getLogger("toot")
@@ -160,7 +160,7 @@ class Timeline(urwid.Columns):
             return
 
         if key in ("n", "N"):
-            if self.can_translate != Option.NO:
+            if self.can_translate:
                 self._emit("translate", status)
             return
 
@@ -233,11 +233,8 @@ class Timeline(urwid.Columns):
         del(self.status_list.body[index])
         self.refresh_status_details()
 
-    def update_can_translate(self, can_translate):
-        self.can_translate = can_translate
-
 class StatusDetails(urwid.Pile):
-    def __init__(self, status, in_thread, can_translate=Option.UNKNOWN):
+    def __init__(self, status, in_thread, can_translate=False):
         """
         Parameters
         ----------
@@ -324,9 +321,7 @@ class StatusDetails(urwid.Pile):
             "[R]eply",
             "So[u]rce",
             "[Z]oom",
-            "Tra[n]slate" if self.can_translate == Option.YES \
-            else "Tra[n]slate?" if self.can_translate == Option.UNKNOWN \
-            else "",
+            "Tra[n]slate" if self.can_translate else "",
             "[H]elp",
         ]
         options = " ".join(o for o in options if o)

--- a/toot/tui/utils.py
+++ b/toot/tui/utils.py
@@ -108,14 +108,3 @@ def parse_content_links(content):
     parser = LinkParser()
     parser.feed(content)
     return parser.links[:]
-
-# This is not as robust as using distutils.version.LooseVersion but for our needs
-# it works fine and doesn't require importing a ton of dependences
-
-def versiontuple(v):
-    return tuple(map(int, (v.split("."))))
-
-class Option:
-    NO = 0
-    YES = 1
-    UNKNOWN = 2

--- a/toot/tui/utils.py
+++ b/toot/tui/utils.py
@@ -108,3 +108,14 @@ def parse_content_links(content):
     parser = LinkParser()
     parser.feed(content)
     return parser.links[:]
+
+# This is not as robust as using distutils.version.LooseVersion but for our needs
+# it works fine and doesn't require importing a ton of dependences
+
+def versiontuple(v):
+    return tuple(map(int, (v.split("."))))
+
+class Option:
+    NO = 0
+    YES = 1
+    UNKNOWN = 2


### PR DESCRIPTION
I've submitted a patch to the mailing list, but hopefully this is cleaner/easier to review.

Implementation as per https://github.com/mastodon/mastodon/pull/19218
and https://github.com/mastodon/mastodon/issues/19328

Screenshots of feature in action.

<img width="938" alt="Screenshot 2022-12-06 192326" src="https://user-images.githubusercontent.com/3261094/206331166-03acc100-c153-4a66-b99b-d1f00627229c.png">
<img width="940" alt="Screenshot 2022-12-06 192407" src="https://user-images.githubusercontent.com/3261094/206331176-e7c22eb6-ecb5-4e51-8a48-f6f442d8eabc.png">
