### PR TITLE
Console and api support for following hashtags

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -23,6 +23,11 @@ def _status_action(app, user, status_id, action):
 
     return http.post(app, user, url).json()
 
+def _tag_action(app, user, tag_name, action):
+    url = '/api/v1/tags/{}/{}'.format(tag_name, action)
+
+    return http.post(app, user, url).json()
+
 
 def create_app(domain, scheme='https'):
     url = '{}://{}/api/v1/apps'.format(scheme, domain)
@@ -312,24 +317,36 @@ def unfollow(app, user, account):
     return _account_action(app, user, account, 'unfollow')
 
 
-def _get_account_list(app, user, path):
-    accounts = []
+def follow_tag(app, user, tag_name):
+    return _tag_action(app, user, tag_name, 'follow')
+
+
+def unfollow_tag(app, user, tag_name):
+    return _tag_action(app, user, tag_name, 'unfollow')
+
+
+def _get_response_list(app, user, path):
+    items = []
     while path:
         response = http.get(app, user, path)
-        accounts += response.json()
+        items += response.json()
         path = _get_next_path(response.headers)
-    return accounts
+    return items
 
 
 def following(app, user, account):
     path = '/api/v1/accounts/{}/{}'.format(account, 'following')
-    return _get_account_list(app, user, path)
+    return _get_responselist(app, user, path)
 
 
 def followers(app, user, account):
     path = '/api/v1/accounts/{}/{}'.format(account, 'followers')
     return _get_account_list(app, user, path)
 
+def followed_tags(app, user):
+    path = '/api/v1/followed_tags'
+    return _get_response_list(app, user, path)
+    
 
 def mute(app, user, account):
     return _account_action(app, user, account, 'mute')

--- a/toot/api.py
+++ b/toot/api.py
@@ -24,6 +24,9 @@ def _status_action(app, user, status_id, action):
     return http.post(app, user, url).json()
 
 def _tag_action(app, user, tag_name, action):
+    # documentation on this API is here, for now
+    # https://github.com/mastodon/mastodon/pull/18809
+    # supported by Mastodon 4+    
     url = '/api/v1/tags/{}/{}'.format(tag_name, action)
 
     return http.post(app, user, url).json()
@@ -336,12 +339,12 @@ def _get_response_list(app, user, path):
 
 def following(app, user, account):
     path = '/api/v1/accounts/{}/{}'.format(account, 'following')
-    return _get_responselist(app, user, path)
+    return _get_response_list(app, user, path)
 
 
 def followers(app, user, account):
     path = '/api/v1/accounts/{}/{}'.format(account, 'followers')
-    return _get_account_list(app, user, path)
+    return _get_response_list(app, user, path)
 
 def followed_tags(app, user):
     path = '/api/v1/followed_tags'

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -8,7 +8,8 @@ from toot import api, config, __version__
 from toot.auth import login_interactive, login_browser_interactive, create_app_interactive
 from toot.exceptions import ApiError, ConsoleError
 from toot.output import (print_out, print_instance, print_account, print_acct_list,
-                         print_search_results, print_timeline, print_notifications)
+                         print_search_results, print_timeline, print_notifications,
+                         print_tag_list)
 from toot.tui.utils import parse_datetime
 from toot.utils import editor_input, multiline_input, EOF_KEY
 
@@ -321,6 +322,22 @@ def followers(app, user, args):
     account = _find_account(app, user, args.account)
     response = api.followers(app, user, account['id'])
     print_acct_list(response)
+
+def follow_tag(app, user, args):
+    tn = args.tag_name if not args.tag_name.startswith("#") else args.tag_name[1:]
+    api.follow_tag(app, user, tn)
+    print_out("<green>✓ You are now following #{}</green>".format(tn))
+
+
+def unfollow_tag(app, user, args):
+    tn = args.tag_name if not args.tag_name.startswith("#") else args.tag_name[1:]
+    api.unfollow_tag(app, user, tn)
+    print_out("<green>✓ You are no longer following #{}</green>".format(tn))
+
+
+def followed_tags(app, user, args):
+    response = api.followed_tags(app, user)
+    print_tag_list(response)
 
 
 def mute(app, user, args):

--- a/toot/console.py
+++ b/toot/console.py
@@ -148,6 +148,13 @@ status_id_arg = (["status_id"], {
     "type": str,
 })
 
+tag_arg = (["tag_name"], {
+    "type": str,
+    "help": "tag name, e.g. Caturday, or \"#Caturday\"",
+})
+
+
+
 # Arguments for selecting a timeline (see `toot.commands.get_timeline_generator`)
 common_timeline_args = [
     (["-p", "--public"], {
@@ -542,7 +549,32 @@ ACCOUNTS_COMMANDS = [
     ),
 ]
 
-COMMANDS = AUTH_COMMANDS + READ_COMMANDS + TUI_COMMANDS + POST_COMMANDS + STATUS_COMMANDS + ACCOUNTS_COMMANDS
+TAG_COMMANDS= [
+    Command(
+        name="follow_tag",
+        description="Follow a hashtag",
+        arguments=[
+            tag_arg,
+        ],
+        require_auth=True,
+    ),
+    Command(
+        name="unfollow_tag",
+        description="Unfollow a hashtag",
+        arguments=[
+            tag_arg,
+        ],
+        require_auth=True,
+    ),
+    Command(
+        name="followed_tags",
+        description="List hashtags followed by the given account",
+        arguments=[account_arg],
+        require_auth=True,
+    ),
+    ]
+
+COMMANDS = AUTH_COMMANDS + READ_COMMANDS + TUI_COMMANDS + POST_COMMANDS + STATUS_COMMANDS + ACCOUNTS_COMMANDS + TAG_COMMANDS
 
 
 def print_usage():
@@ -555,6 +587,7 @@ def print_usage():
         ("Post", POST_COMMANDS),
         ("Status", STATUS_COMMANDS),
         ("Accounts", ACCOUNTS_COMMANDS),
+        ("Hashtags", TAG_COMMANDS),
     ]
 
     print_out("<green>{}</green>".format(CLIENT_NAME))

--- a/toot/console.py
+++ b/toot/console.py
@@ -568,8 +568,8 @@ TAG_COMMANDS= [
     ),
     Command(
         name="followed_tags",
-        description="List hashtags followed by the given account",
-        arguments=[account_arg],
+        description="List hashtags you follow",
+        arguments=[],
         require_auth=True,
     ),
     ]

--- a/toot/output.py
+++ b/toot/output.py
@@ -200,7 +200,7 @@ def print_acct_list(accounts):
 
 def print_tag_list(tags):
     for tag in tags:
-        print_out(f"* <green>#{tag['name']}\t\t</green> {tag['url']}")
+        print_out(f"* <green>#{tag['name']}\t</green> {tag['url']}")
 
 
 def print_search_results(results):

--- a/toot/output.py
+++ b/toot/output.py
@@ -198,6 +198,11 @@ def print_acct_list(accounts):
         print_out(f"* <green>@{account['acct']}</green> {account['display_name']}")
 
 
+def print_tag_list(tags):
+    for tag in tags:
+        print_out(f"* <green>#{tag['name']}\t\t</green> {tag['url']}")
+
+
 def print_search_results(results):
     accounts = results['accounts']
     hashtags = results['hashtags']


### PR DESCRIPTION
Mastodon 4 allows you to follow hashtags. This pull request implements basic console and api level support for the feature.

```
toot follow_tag tagname
toot unfollow_tag tagname
toot followed_tags

```
The commands have slightly awkward names as they can be confused with the account follow / unfollow commands.  If you can think of better names, it might be worth switching.

* note: this pull request is a subset of pull request #266 so please accept one or the other, but there is no need to accept both.



https://github.com/ihabunek/toot/issues/264