### PR TITLE
Scrolling status details and inline ANSI graphics previews

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests>=2.13,<3.0
 beautifulsoup4>=4.5.0,<5.0
 wcwidth>=0.1.7
 urwid>=2.0.0,<3.0
+pillow>=9.2.0
+ansicolors>=1.1.8

--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -45,7 +45,7 @@ class StatusLinks(urwid.ListBox):
 class ExceptionStackTrace(urwid.ListBox):
     """Shows an exception stack trace."""
     def __init__(self, ex):
-        lines = traceback.format_exception(etype=type(ex), value=ex, tb=ex.__traceback__)
+        lines = traceback.format_exception(type(ex), value=ex, tb=ex.__traceback__)
         walker = urwid.SimpleFocusListWalker([
             urwid.Text(line) for line in lines
         ])

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -1,12 +1,16 @@
 import logging
+import math
 import urwid
 import webbrowser
 
 from toot.utils import format_content
 from toot.utils.language import language_name
 
-from .utils import highlight_hashtags, parse_datetime, highlight_keys
-from .widgets import SelectableText, SelectableColumns
+from toot.tui.utils import highlight_hashtags, parse_datetime, highlight_keys, resize_image
+from toot.tui.widgets import SelectableText, SelectableColumns
+from toot.tui.ansiwidget import ANSIGraphicsWidget
+from toot.tui.scroll import Scrollable, ScrollBar
+from PIL import Image
 
 logger = logging.getLogger("toot")
 
@@ -32,6 +36,7 @@ class Timeline(urwid.Columns):
         "translate",  # Translate status
         "save",       # Save current timeline
         "zoom",       # Open status in scrollable popup window
+        "load-image",  # used internally. asynchronously load image
     ]
 
     def __init__(self, name, statuses, can_translate, focus=0, is_thread=False):
@@ -41,15 +46,20 @@ class Timeline(urwid.Columns):
         self.can_translate = can_translate
         self.status_list = self.build_status_list(statuses, focus=focus)
         try:
-            self.status_details = StatusDetails(statuses[focus], is_thread, can_translate)
+            self.status_details = ScrollBar(Scrollable( \
+                StatusDetails(self, statuses[focus], is_thread, can_translate)))
         except IndexError:
-            self.status_details = StatusDetails(None, is_thread, can_translate)
+            self.status_details = ScrollBar( \
+                Scrollable(StatusDetails(self, None, is_thread, can_translate)))
 
         super().__init__([
             ("weight", 40, self.status_list),
             ("weight", 0, urwid.AttrWrap(urwid.SolidFill("│"), "blue_selected")),
             ("weight", 60, urwid.Padding(self.status_details, left=1)),
         ])
+
+    def selectable(self):
+        return True
 
     def build_status_list(self, statuses, focus):
         items = [self.build_list_item(status) for status in statuses]
@@ -100,8 +110,10 @@ class Timeline(urwid.Columns):
         self.draw_status_details(status)
 
     def draw_status_details(self, status):
-        self.status_details = StatusDetails(status, self.is_thread, self.can_translate)
-        self.contents[2] = urwid.Padding(self.status_details, left=1), ("weight", 60, False)
+        self.status_details = StatusDetails(self, status, self.is_thread, self.can_translate)
+        self.contents[2] = urwid.Padding(ScrollBar(Scrollable(self.status_details),\
+                                                    thumb_char='\u2588', trough_char='\u2591'),\
+                                            left=1), ("weight", 60, False)
 
     def keypress(self, size, key):
         status = self.get_focused_status()
@@ -236,7 +248,7 @@ class Timeline(urwid.Columns):
 
 
 class StatusDetails(urwid.Pile):
-    def __init__(self, status, in_thread, can_translate=False):
+    def __init__(self, timeline, status, in_thread, can_translate=False):
         """
         Parameters
         ----------
@@ -248,6 +260,9 @@ class StatusDetails(urwid.Pile):
         """
         self.in_thread = in_thread
         self.can_translate = can_translate
+        self.timeline = timeline
+        self.status = status
+
         reblogged_by = status.author if status and status.reblog else None
         widget_list = list(self.content_generator(status.original, reblogged_by)
             if status else ())
@@ -265,6 +280,15 @@ class StatusDetails(urwid.Pile):
         yield ("pack", urwid.Text(("yellow", status.author.account)))
         yield ("pack", urwid.Divider())
 
+#        if status.data["account"]["avatar_static"]:
+#            try:
+#                avatar = self.load_image(6, status.data["account"]["avatar_static"])
+#                rows = avatar.size[1]
+#                yield ("pack", urwid.BoxAdapter(ANSIGraphicsWidget(avatar),math.ceil(rows/2)))
+#                yield ("pack", urwid.Divider())
+#            finally:
+#                pass #ignore any error
+
         if status.data["spoiler_text"]:
             yield ("pack", urwid.Text(status.data["spoiler_text"]))
             yield ("pack", urwid.Divider())
@@ -277,24 +301,25 @@ class StatusDetails(urwid.Pile):
             for line in format_content(content):
                 yield ("pack", urwid.Text(highlight_hashtags(line)))
 
-        media = status.data["media_attachments"]
-        if media:
-            for m in media:
-                yield ("pack", urwid.AttrMap(urwid.Divider("-"), "gray"))
-                yield ("pack", urwid.Text([("bold", "Media attachment"), " (", m["type"], ")"]))
-                if m["description"]:
-                    yield ("pack", urwid.Text(m["description"]))
-                yield ("pack", urwid.Text(("link", m["url"])))
+            media = status.data["media_attachments"]
+            if media:
+                for m in media:
+                    yield ("pack", urwid.AttrMap(urwid.Divider("-"), "gray"))
+                    yield ("pack", urwid.Text([("bold", "Media attachment"), " (", m["type"], ")"]))
+                    if m["description"]:
+                        yield ("pack", urwid.Text(m["description"]))
+                    if m["url"]:
+                        yield ("pack", urwid.Text(m["url"]))
 
-        poll = status.data.get("poll")
-        if poll:
-            yield ("pack", urwid.Divider())
-            yield ("pack", self.build_linebox(self.poll_generator(poll)))
+            poll = status.data.get("poll")
+            if poll:
+                yield ("pack", urwid.Divider())
+                yield ("pack", self.build_linebox(self.poll_generator(poll)))
 
-        card = status.data.get("card")
-        if card:
-            yield ("pack", urwid.Divider())
-            yield ("pack", self.build_linebox(self.card_generator(card)))
+            card = status.data.get("card")
+            if card:
+                yield ("pack", urwid.Divider())
+                yield ("pack", self.build_linebox(self.card_generator(card)))
 
         application = status.data.get("application") or {}
         application = application.get("name")
@@ -316,7 +341,7 @@ class StatusDetails(urwid.Pile):
         ]))
 
         # Push things to bottom
-        yield ("weight", 1, urwid.SolidFill(" "))
+        yield ("weight", 1, urwid.BoxAdapter(urwid.SolidFill(" "),1))
 
         options = [
             "[B]oost",
@@ -349,7 +374,26 @@ class StatusDetails(urwid.Pile):
         if card["description"]:
             yield urwid.Text(card["description"].strip())
             yield urwid.Text("")
+
         yield urwid.Text(("link", card["url"]))
+
+        if card["image"]:
+            if card["image"].lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.svg')):
+                yield urwid.Text("")
+
+                ratio = int(card["height"]) / int(card["width"])
+                rows = math.ceil(20 * ratio)
+
+                img = None
+                if hasattr(self.status,'images'):
+                    img = self.status.images.get(str(hash(card["image"])))
+                if img:
+                    img = resize_image(40, img)
+                    yield("pack", urwid.BoxAdapter(ANSIGraphicsWidget(img),rows))
+                else:
+                    self.timeline._emit("load-image", self.timeline, self.status, card["image"])
+                    yield("pack", urwid.BoxAdapter(urwid.SolidFill(fill_char=" "),rows))
+
 
     def poll_generator(self, poll):
         for idx, option in enumerate(poll["options"]):

--- a/toot/tui/utils.py
+++ b/toot/tui/utils.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 
 from datetime import datetime, timezone
+from PIL import Image
 
 HASHTAG_PATTERN = re.compile(r'(?<!\w)(#\w+)\b')
 
@@ -108,3 +109,11 @@ def parse_content_links(content):
     parser = LinkParser()
     parser.feed(content)
     return parser.links[:]
+
+
+def resize_image(basewidth: int, img: Image) -> Image:
+        wpercent = (basewidth/float(img.size[0]))
+        hsize = int((float(img.size[1])*float(wpercent)))
+        img = img.resize((basewidth,hsize), Image.ANTIALIAS)
+        img = img.convert('RGB')
+        return img


### PR DESCRIPTION
This pull request adds scrolling status details (right-arrow in timeline shifts focus to the status detail window, then up/down arrows allow you to scroll.  left-arrow gets you back to the timeline.)  It also adds ANSI graphics previews for card images.  Images are asychronously loaded.   This could be extended to add previews for media attachments (.png, .jpg, etc.) but there are some threading issues to work out before that can be done properly.
![Screenshot 2022-12-24 194323](https://user-images.githubusercontent.com/3261094/209454933-c057f35d-2ada-45d0-bc51-6636a1845bd4.png)

Note that this does add two new library dependencies; Pillow (PIL) and ansicolors. 