### PR TITLE
Screen refresh after console-web-browser invocation and exit

### DIFF
--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -208,6 +208,7 @@ class TUI(urwid.Frame):
         urwid.connect_signal(timeline, "links", _links)
         urwid.connect_signal(timeline, "zoom", _zoom)
         urwid.connect_signal(timeline, "translate", self.async_translate)
+        urwid.connect_signal(timeline, "clear-screen", self.loop.screen.clear)
 
     def build_timeline(self, name, statuses, local):
         def _close(*args):
@@ -345,6 +346,9 @@ class TUI(urwid.Frame):
             title="Status source",
         )
 
+    def _clear_screen(self,  widget):
+            self.loop.screen.clear()
+
     def show_links(self, status):
         links = parse_content_links(status.data["content"]) if status else []
         post_attachments = status.data["media_attachments"] or []
@@ -353,8 +357,10 @@ class TUI(urwid.Frame):
             url = a["remote_url"] or a["url"]
             links.append((url, a["description"] if a["description"] else url))
         if links:
+            sl_widget=StatusLinks(links)
+            urwid.connect_signal(sl_widget, "clear-screen", self._clear_screen)
             self.open_overlay(
-                widget=StatusLinks(links),
+                widget=sl_widget,
                 title="Status links",
                 options={"height": len(links) + 2},
             )

--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -30,16 +30,22 @@ class StatusZoom(urwid.ListBox):
 
 class StatusLinks(urwid.ListBox):
     """Shows status links."""
+    signals = ["clear-screen"]
 
     def __init__(self, links):
 
         def widget(url, title):
-            return Button(title or url, on_press=lambda btn: webbrowser.open(url))
+            return Button(title or url, on_press=lambda btn: self.browse(url))
 
         walker = urwid.SimpleFocusListWalker(
             [widget(url, title) for url, title in links]
         )
         super().__init__(walker)
+
+    def browse(self, url):
+        webbrowser.open(url)
+        # force a screen refresh; necessary with console browsers
+        self._emit("clear-screen")
 
 
 class ExceptionStackTrace(urwid.ListBox):

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -32,6 +32,7 @@ class Timeline(urwid.Columns):
         "translate",  # Translate status
         "save",       # Save current timeline
         "zoom",       # Open status in scrollable popup window
+        "clear-screen", # clear the screen (used internally)
     ]
 
     def __init__(self, name, statuses, can_translate, focus=0, is_thread=False):
@@ -176,6 +177,8 @@ class Timeline(urwid.Columns):
         if key in ("v", "V"):
             if status.original.url:
                 webbrowser.open(status.original.url)
+                # force a screen refresh; necessary with console browsers
+                self._emit("clear-screen")
             return
 
         if key in ("p", "P"):


### PR DESCRIPTION
This checks to see if you're launching an in-console webbrowser and if so, after quitting the browser, it forces a screen refresh so you see the TUI again.  Fix for #271  