### PR TITLE
Scrolling status details window and ANSI graphics preview of card images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ requests>=2.13,<3.0
 beautifulsoup4>=4.5.0,<5.0
 wcwidth>=0.1.7
 urwid>=2.0.0,<3.0
+pillow>=9.2.0
+ansicolors>=1.1.8

--- a/toot/tui/ansiwidget.py
+++ b/toot/tui/ansiwidget.py
@@ -1,0 +1,117 @@
+from typing import Tuple, List, Optional, Any, Iterable
+
+import re
+import urwid
+from PIL import Image
+from colors import color
+
+class ANSIGraphicsCanvas(urwid.canvas.Canvas):
+    def __init__(self, size: Tuple[int, int], img: Image) -> None:
+        super().__init__()
+
+        self.maxcols = size[0]
+        if len(size) > 1:
+            self.maxrows = size[1]
+
+        self.img = img
+        self.text_lines = []
+        self.ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+        self.ansi_escape_capture = re.compile(r'(\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]))')
+
+    def cols(self) -> int:
+        return self.maxcols
+
+    def rows(self) -> int:
+        return self.maxrows
+
+    def strip_ansi_codes(self, ansi_text):
+        return self.ansi_escape.sub('', ansi_text)
+
+    def truncate_ansi_safe(self, ansi_text, trim_left, maxlength):
+        if len(self.strip_ansi_codes(ansi_text)) <= maxlength:
+            return ansi_text
+
+        trunc_text = ''
+        real_len = 0
+        token_pt_len = 0
+
+        for token in re.split(self.ansi_escape_capture, ansi_text):
+            if token and token[0] == '\x1b':
+                # this token is an ANSI sequence so just add it
+                trunc_text += token
+            else:
+                # this token is plaintext so add chars if we can
+                if token_pt_len + len(token) < trim_left:
+                    # this token is entirely within trim zone
+                    # skip it
+                    token_pt_len += len(token)
+                    continue
+                if token_pt_len < trim_left:
+                    # this token is partially within trim zone
+                    # partially skip, partially add
+                    token_pt_len += len(token)
+                    token = token[trim_left - token_pt_len + 1:]
+
+                token_slice = token[:maxlength - real_len + 1]
+                trunc_text += token_slice
+                real_len += len(token_slice)
+
+            if real_len >= maxlength + trim_left:
+                break
+
+        return trunc_text
+
+    def content(
+        self,
+        trim_left: int = 0, trim_top: int = 0,
+        cols: Optional[int] = None, rows: Optional[int] = None,
+        attr_map: Optional[Any] = None
+    ) -> Iterable[List[Tuple[None, str, bytes]]]:
+        assert cols is not None
+        assert rows is not None
+
+        ansi_reset = '\x1b[0m'.encode('utf-8')
+
+#        if trim_top or rows < self.maxrows:
+#            self.text_lines = self.text_lines[trim_top:trim_top+rows]
+
+        if len(self.text_lines) == 0:
+             width, height = self.img.size
+             for i in range(1, height-1, 2):
+                line = ''
+                for j in range(1, width):
+                        ra, ga, ba = self.img.getpixel((j, i))
+                        rb, gb, bb = self.img.getpixel((j, i+1))
+                        # render via unicode half-blocks
+                        line += color('\u2584', fg=(rb, gb, bb), bg=(ra, ga, ba))
+                self.text_lines.append(line)
+
+        for i in range(rows):
+            if  i < len(self.text_lines):
+                text = self.truncate_ansi_safe(self.text_lines[i], trim_left, cols - 1)
+                real_len = len(self.strip_ansi_codes(text))
+                text_bytes = text.encode('utf-8')
+            else:
+                text_bytes = b''
+                real_len = 0
+
+            padding = bytes().rjust(max(0, cols - real_len))
+            line = [(None, 'U', text_bytes + padding + ansi_reset)]
+            yield line
+
+
+class ANSIGraphicsWidget(urwid.Widget):
+    _sizing = frozenset([urwid.widget.BOX])
+    ignore_focus = True
+
+    def __init__(self, img: Image) -> None:
+        urwid.set_encoding('utf8')
+        self.img = img
+
+    def set_content(self, img: Image) -> None:
+        self.img = img
+        self.text_lines = []
+        self._invalidate()
+
+    def render(self, size: Tuple[int, int], focus: bool = False) -> urwid.canvas.Canvas:
+        return ANSIGraphicsCanvas(size, self.img)

--- a/toot/tui/ansiwidget.py
+++ b/toot/tui/ansiwidget.py
@@ -72,19 +72,19 @@ class ANSIGraphicsCanvas(urwid.canvas.Canvas):
 
         ansi_reset = '\x1b[0m'.encode('utf-8')
 
-#        if trim_top or rows < self.maxrows:
-#            self.text_lines = self.text_lines[trim_top:trim_top+rows]
+        self.text_lines = []
+        width, height = self.img.size
+        for i in range(1, height-1, 2):
+            line = ''
+            for j in range(1, width):
+                    ra, ga, ba = self.img.getpixel((j, i))
+                    rb, gb, bb = self.img.getpixel((j, i+1))
+                    # render via unicode half-blocks
+                    line += color('\u2584', fg=(rb, gb, bb), bg=(ra, ga, ba))
+            self.text_lines.append(line)
 
-        if len(self.text_lines) == 0:
-             width, height = self.img.size
-             for i in range(1, height-1, 2):
-                line = ''
-                for j in range(1, width):
-                        ra, ga, ba = self.img.getpixel((j, i))
-                        rb, gb, bb = self.img.getpixel((j, i+1))
-                        # render via unicode half-blocks
-                        line += color('\u2584', fg=(rb, gb, bb), bg=(ra, ga, ba))
-                self.text_lines.append(line)
+        if trim_top or rows < self.maxrows:
+            self.text_lines = self.text_lines[trim_top:trim_top+rows]
 
         for i in range(rows):
             if  i < len(self.text_lines):

--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -45,7 +45,7 @@ class StatusLinks(urwid.ListBox):
 class ExceptionStackTrace(urwid.ListBox):
     """Shows an exception stack trace."""
     def __init__(self, ex):
-        lines = traceback.format_exception(etype=type(ex), value=ex, tb=ex.__traceback__)
+        lines = traceback.format_exception(type(ex), value=ex, tb=ex.__traceback__)
         walker = urwid.SimpleFocusListWalker([
             urwid.Text(line) for line in lines
         ])

--- a/toot/tui/scroll.py
+++ b/toot/tui/scroll.py
@@ -1,0 +1,425 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details
+# http://www.gnu.org/licenses/gpl-3.0.txt
+#
+# Copied from the stig project by rndusr@github
+# https://github.com/rndusr/stig
+#
+
+import urwid
+from urwid.widget import BOX, FIXED, FLOW
+
+# Scroll actions
+SCROLL_LINE_UP        = 'line up'
+SCROLL_LINE_DOWN      = 'line down'
+SCROLL_PAGE_UP        = 'page up'
+SCROLL_PAGE_DOWN      = 'page down'
+SCROLL_TO_TOP         = 'to top'
+SCROLL_TO_END         = 'to end'
+
+# Scrollbar positions
+SCROLLBAR_LEFT  = 'left'
+SCROLLBAR_RIGHT = 'right'
+
+class Scrollable(urwid.WidgetDecoration):
+    def sizing(self):
+        return frozenset([BOX,])
+
+    def selectable(self):
+        return True
+
+    def __init__(self, widget):
+        """Box widget that makes a fixed or flow widget vertically scrollable
+
+        TODO: Focusable widgets are handled, including switching focus, but
+        possibly not intuitively, depending on the arrangement of widgets.  When
+        switching focus to a widget that is outside of the visible part of the
+        original widget, the canvas scrolls up/down to the focused widget.  It
+        would be better to scroll until the next focusable widget is in sight
+        first.  But for that to work we must somehow obtain a list of focusable
+        rows in the original canvas.
+        """
+        if not any(s in widget.sizing() for s in (FIXED, FLOW)):
+            raise ValueError('Not a fixed or flow widget: %r' % widget)
+        self._trim_top = 0
+        self._scroll_action = None
+        self._forward_keypress = None
+        self._old_cursor_coords = None
+        self._rows_max_cached = 0
+        self.__super.__init__(widget)
+
+    def render(self, size, focus=False):
+        maxcol, maxrow = size
+
+        # Render complete original widget
+        ow = self._original_widget
+        ow_size = self._get_original_widget_size(size)
+        canv_full = ow.render(ow_size, focus)
+
+        # Make full canvas editable
+        canv = urwid.CompositeCanvas(canv_full)
+        canv_cols, canv_rows = canv.cols(), canv.rows()
+
+        if canv_cols <= maxcol:
+            pad_width = maxcol - canv_cols
+            if pad_width > 0:
+                # Canvas is narrower than available horizontal space
+                canv.pad_trim_left_right(0, pad_width)
+
+        if canv_rows <= maxrow:
+            fill_height = maxrow - canv_rows
+            if fill_height > 0:
+                # Canvas is lower than available vertical space
+                canv.pad_trim_top_bottom(0, fill_height)
+
+        if canv_cols <= maxcol and canv_rows <= maxrow:
+            # Canvas is small enough to fit without trimming
+            return canv
+
+        self._adjust_trim_top(canv, size)
+
+        # Trim canvas if necessary
+        trim_top = self._trim_top
+        trim_end = canv_rows - maxrow - trim_top
+        trim_right = canv_cols - maxcol
+        if trim_top > 0:
+            canv.trim(trim_top)
+        if trim_end > 0:
+            canv.trim_end(trim_end)
+        if trim_right > 0:
+            canv.pad_trim_left_right(0, -trim_right)
+
+        # Disable cursor display if cursor is outside of visible canvas parts
+        if canv.cursor is not None:
+            curscol, cursrow = canv.cursor
+            if cursrow >= maxrow or cursrow < 0:
+                canv.cursor = None
+
+        # Figure out whether we should forward keypresses to original widget
+        if canv.cursor is not None:
+            # Trimmed canvas contains the cursor, e.g. in an Edit widget
+            self._forward_keypress = True
+        else:
+            if canv_full.cursor is not None:
+                # Full canvas contains the cursor, but scrolled out of view
+                self._forward_keypress = False
+            else:
+                # Original widget does not have a cursor, but may be selectable
+
+                # FIXME: Using ow.selectable() is bad because the original
+                # widget may be selectable because it's a container widget with
+                # a key-grabbing widget that is scrolled out of view.
+                # ow.selectable() returns True anyway because it doesn't know
+                # how we trimmed our canvas.
+                #
+                # To fix this, we need to resolve ow.focus and somehow
+                # ask canv whether it contains bits of the focused widget.  I
+                # can't see a way to do that.
+                if ow.selectable():
+                    self._forward_keypress = True
+                else:
+                    self._forward_keypress = False
+
+        return canv
+
+    def keypress(self, size, key):
+        # Maybe offer key to original widget
+        if self._forward_keypress:
+            ow = self._original_widget
+            ow_size = self._get_original_widget_size(size)
+
+            # Remember previous cursor position if possible
+            if hasattr(ow, 'get_cursor_coords'):
+                self._old_cursor_coords = ow.get_cursor_coords(ow_size)
+
+            key = ow.keypress(ow_size, key)
+            if key is None:
+                return None
+
+        # Handle up/down, page up/down, etc
+        command_map = self._command_map
+        if command_map[key] == urwid.CURSOR_UP:
+            self._scroll_action = SCROLL_LINE_UP
+        elif command_map[key] == urwid.CURSOR_DOWN:
+            self._scroll_action = SCROLL_LINE_DOWN
+
+        elif command_map[key] == urwid.CURSOR_PAGE_UP:
+            self._scroll_action = SCROLL_PAGE_UP
+        elif command_map[key] == urwid.CURSOR_PAGE_DOWN:
+            self._scroll_action = SCROLL_PAGE_DOWN
+
+        elif command_map[key] == urwid.CURSOR_MAX_LEFT:   # 'home'
+            self._scroll_action = SCROLL_TO_TOP
+        elif command_map[key] == urwid.CURSOR_MAX_RIGHT:  # 'end'
+            self._scroll_action = SCROLL_TO_END
+
+        else:
+            return key
+
+        self._invalidate()
+
+    def mouse_event(self, size, event, button, col, row, focus):
+        ow = self._original_widget
+        if hasattr(ow, 'mouse_event'):
+            ow_size = self._get_original_widget_size(size)
+            row += self._trim_top
+            return ow.mouse_event(ow_size, event, button, col, row, focus)
+        else:
+            return False
+
+    def _adjust_trim_top(self, canv, size):
+        """Adjust self._trim_top according to self._scroll_action"""
+        action = self._scroll_action
+        self._scroll_action = None
+
+        maxcol, maxrow = size
+        trim_top = self._trim_top
+        canv_rows = canv.rows()
+
+        if trim_top < 0:
+            # Negative trim_top values use bottom of canvas as reference
+            trim_top = canv_rows - maxrow + trim_top + 1
+
+        if canv_rows <= maxrow:
+            self._trim_top = 0  # Reset scroll position
+            return
+
+        def ensure_bounds(new_trim_top):
+            return max(0, min(canv_rows - maxrow, new_trim_top))
+
+        if action == SCROLL_LINE_UP:
+            self._trim_top = ensure_bounds(trim_top - 1)
+        elif action == SCROLL_LINE_DOWN:
+            self._trim_top = ensure_bounds(trim_top + 1)
+
+        elif action == SCROLL_PAGE_UP:
+            self._trim_top = ensure_bounds(trim_top - maxrow + 1)
+        elif action == SCROLL_PAGE_DOWN:
+            self._trim_top = ensure_bounds(trim_top + maxrow - 1)
+
+        elif action == SCROLL_TO_TOP:
+            self._trim_top = 0
+        elif action == SCROLL_TO_END:
+            self._trim_top = canv_rows - maxrow
+
+        else:
+            self._trim_top = ensure_bounds(trim_top)
+
+        # If the cursor was moved by the most recent keypress, adjust trim_top
+        # so that the new cursor position is within the displayed canvas part.
+        # But don't do this if the cursor is at the top/bottom edge so we can still scroll out
+        if self._old_cursor_coords is not None and self._old_cursor_coords != canv.cursor:
+            self._old_cursor_coords = None
+            curscol, cursrow = canv.cursor
+            if cursrow < self._trim_top:
+                self._trim_top = cursrow
+            elif cursrow >= self._trim_top + maxrow:
+                self._trim_top = max(0, cursrow - maxrow + 1)
+
+    def _get_original_widget_size(self, size):
+        ow = self._original_widget
+        sizing = ow.sizing()
+        if FIXED in sizing:
+            return ()
+        elif FLOW in sizing:
+            return (size[0],)
+
+    def get_scrollpos(self, size=None, focus=False):
+        """Current scrolling position
+
+        Lower limit is 0, upper limit is the maximum number of rows with the
+        given maxcol minus maxrow.
+
+        NOTE: The returned value may be too low or too high if the position has
+        changed but the widget wasn't rendered yet.
+        """
+        return self._trim_top
+
+    def set_scrollpos(self, position):
+        """Set scrolling position
+
+        If `position` is positive it is interpreted as lines from the top.
+        If `position` is negative it is interpreted as lines from the bottom.
+
+        Values that are too high or too low values are automatically adjusted
+        during rendering.
+        """
+        self._trim_top = int(position)
+        self._invalidate()
+
+    def rows_max(self, size=None, focus=False):
+        """Return the number of rows for `size`
+
+        If `size` is not given, the currently rendered number of rows is returned.
+        """
+        if size is not None:
+            ow = self._original_widget
+            ow_size = self._get_original_widget_size(size)
+            sizing = ow.sizing()
+            if FIXED in sizing:
+                self._rows_max_cached = ow.pack(ow_size, focus)[1]
+            elif FLOW in sizing:
+                self._rows_max_cached = ow.rows(ow_size, focus)
+            else:
+                raise RuntimeError('Not a flow/box widget: %r' % self._original_widget)
+        return self._rows_max_cached
+
+
+class ScrollBar(urwid.WidgetDecoration):
+    def sizing(self):
+        return frozenset((BOX,))
+
+    def selectable(self):
+        return True
+
+    def __init__(self, widget, thumb_char=u'\u2588', trough_char=' ',
+                 side=SCROLLBAR_RIGHT, width=1):
+        """Box widget that adds a scrollbar to `widget`
+
+        `widget` must be a box widget with the following methods:
+          - `get_scrollpos` takes the arguments `size` and `focus` and returns
+            the index of the first visible row.
+          - `set_scrollpos` (optional; needed for mouse click support) takes the
+            index of the first visible row.
+          - `rows_max` takes `size` and `focus` and returns the total number of
+            rows `widget` can render.
+
+        `thumb_char` is the character used for the scrollbar handle.
+        `trough_char` is used for the space above and below the handle.
+        `side` must be 'left' or 'right'.
+        `width` specifies the number of columns the scrollbar uses.
+        """
+        if BOX not in widget.sizing():
+            raise ValueError('Not a box widget: %r' % widget)
+        self.__super.__init__(widget)
+        self._thumb_char = thumb_char
+        self._trough_char = trough_char
+        self.scrollbar_side = side
+        self.scrollbar_width = max(1, width)
+        self._original_widget_size = (0, 0)
+
+    def render(self, size, focus=False):
+        maxcol, maxrow = size
+
+        sb_width = self._scrollbar_width
+        ow_size = (max(0, maxcol - sb_width), maxrow)
+        sb_width = maxcol - ow_size[0]
+
+        ow = self._original_widget
+        ow_base = self.scrolling_base_widget
+        ow_rows_max = ow_base.rows_max(size, focus)
+        if ow_rows_max <= maxrow:
+            # Canvas fits without scrolling - no scrollbar needed
+            self._original_widget_size = size
+            return ow.render(size, focus)
+        ow_rows_max = ow_base.rows_max(ow_size, focus)
+
+        ow_canv = ow.render(ow_size, focus)
+        self._original_widget_size = ow_size
+
+        pos = ow_base.get_scrollpos(ow_size, focus)
+        posmax = ow_rows_max - maxrow
+
+        # Thumb shrinks/grows according to the ratio of
+        # <number of visible lines> / <number of total lines>
+        thumb_weight = min(1, maxrow / max(1, ow_rows_max))
+        thumb_height = max(1, round(thumb_weight * maxrow))
+
+        # Thumb may only touch top/bottom if the first/last row is visible
+        top_weight = float(pos) / max(1, posmax)
+        top_height = int((maxrow - thumb_height) * top_weight)
+        if top_height == 0 and top_weight > 0:
+            top_height = 1
+
+        # Bottom part is remaining space
+        bottom_height = maxrow - thumb_height - top_height
+        assert thumb_height + top_height + bottom_height == maxrow
+
+        # Create scrollbar canvas
+        # Creating SolidCanvases of correct height may result in "cviews do not
+        # fill gaps in shard_tail!" or "cviews overflow gaps in shard_tail!"
+        # exceptions. Stacking the same SolidCanvas is a workaround.
+        # https://github.com/urwid/urwid/issues/226#issuecomment-437176837
+        top = urwid.SolidCanvas(self._trough_char, sb_width, 1)
+        thumb = urwid.SolidCanvas(self._thumb_char, sb_width, 1)
+        bottom = urwid.SolidCanvas(self._trough_char, sb_width, 1)
+        sb_canv = urwid.CanvasCombine(
+            [(top, None, False)] * top_height +
+            [(thumb, None, False)] * thumb_height +
+            [(bottom, None, False)] * bottom_height,
+        )
+
+        combinelist = [(ow_canv, None, True, ow_size[0]),
+                       (sb_canv, None, False, sb_width)]
+        if self._scrollbar_side != SCROLLBAR_LEFT:
+            return urwid.CanvasJoin(combinelist)
+        else:
+            return urwid.CanvasJoin(reversed(combinelist))
+
+    @property
+    def scrollbar_width(self):
+        """Columns the scrollbar uses"""
+        return max(1, self._scrollbar_width)
+
+    @scrollbar_width.setter
+    def scrollbar_width(self, width):
+        self._scrollbar_width = max(1, int(width))
+        self._invalidate()
+
+    @property
+    def scrollbar_side(self):
+        """Where to display the scrollbar; must be 'left' or 'right'"""
+        return self._scrollbar_side
+
+    @scrollbar_side.setter
+    def scrollbar_side(self, side):
+        if side not in (SCROLLBAR_LEFT, SCROLLBAR_RIGHT):
+            raise ValueError('scrollbar_side must be "left" or "right", not %r' % side)
+        self._scrollbar_side = side
+        self._invalidate()
+
+    @property
+    def scrolling_base_widget(self):
+        """Nearest `original_widget` that is compatible with the scrolling API"""
+        def orig_iter(w):
+            while hasattr(w, 'original_widget'):
+                w = w.original_widget
+                yield w
+            yield w
+
+        def is_scrolling_widget(w):
+            return hasattr(w, 'get_scrollpos') and hasattr(w, 'rows_max')
+
+        for w in orig_iter(self):
+            if is_scrolling_widget(w):
+                return w
+        raise ValueError('Not compatible to be wrapped by ScrollBar: %r' % w)
+
+    def keypress(self, size, key):
+        return self._original_widget.keypress(self._original_widget_size, key)
+
+    def mouse_event(self, size, event, button, col, row, focus):
+        ow = self._original_widget
+        ow_size = self._original_widget_size
+        handled = False
+        if hasattr(ow, 'mouse_event'):
+            handled = ow.mouse_event(ow_size, event, button, col, row, focus)
+
+        if not handled and hasattr(ow, 'set_scrollpos'):
+            if button == 4:    # scroll wheel up
+                pos = ow.get_scrollpos(ow_size)
+                ow.set_scrollpos(pos - 1)
+                return True
+            elif button == 5:  # scroll wheel down
+                pos = ow.get_scrollpos(ow_size)
+                ow.set_scrollpos(pos + 1)
+                return True
+
+        return False

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -1,12 +1,16 @@
 import logging
+import math
 import urwid
 import webbrowser
 
 from toot.utils import format_content
 from toot.utils.language import language_name
 
-from .utils import highlight_hashtags, parse_datetime, highlight_keys
-from .widgets import SelectableText, SelectableColumns
+from toot.tui.utils import highlight_hashtags, parse_datetime, highlight_keys, resize_image
+from toot.tui.widgets import SelectableText, SelectableColumns
+from toot.tui.ansiwidget import ANSIGraphicsWidget
+from toot.tui.scroll import Scrollable, ScrollBar
+from PIL import Image
 
 logger = logging.getLogger("toot")
 
@@ -32,6 +36,7 @@ class Timeline(urwid.Columns):
         "translate",  # Translate status
         "save",       # Save current timeline
         "zoom",       # Open status in scrollable popup window
+        "load-image",  # used internally. asynchronously load image
     ]
 
     def __init__(self, name, statuses, can_translate, focus=0, is_thread=False):
@@ -40,16 +45,29 @@ class Timeline(urwid.Columns):
         self.statuses = statuses
         self.can_translate = can_translate
         self.status_list = self.build_status_list(statuses, focus=focus)
+
+        opts_footer = (urwid.Text(self.get_option_text(statuses[focus])))
+
         try:
-            self.status_details = StatusDetails(statuses[focus], is_thread, can_translate)
+            self.status_details = \
+            urwid.Frame(body=\
+                ScrollBar(Scrollable(\
+                    StatusDetails(self, statuses[focus], is_thread, can_translate)),\
+                    thumb_char='\u2588', trough_char='\u2591'),\
+                footer=opts_footer)
+
         except IndexError:
-            self.status_details = StatusDetails(None, is_thread, can_translate)
+            # we have no statuses to display
+            self.status_details = StatusDetails(self, None, is_thread, can_translate)
 
         super().__init__([
             ("weight", 40, self.status_list),
             ("weight", 0, urwid.AttrWrap(urwid.SolidFill("│"), "blue_selected")),
             ("weight", 60, urwid.Padding(self.status_details, left=1)),
         ])
+
+    def selectable(self):
+        return True
 
     def build_status_list(self, statuses, focus):
         items = [self.build_list_item(status) for status in statuses]
@@ -88,6 +106,24 @@ class Timeline(urwid.Columns):
             len(self.statuses),
         )
 
+    def get_option_text(self, status):
+        options = [
+            "[B]oost",
+            "[D]elete" if status.is_mine else "",
+            "[F]avourite",
+            "[V]iew",
+            "[T]hread" if not self.is_thread else "",
+            "[L]inks",
+            "[R]eply",
+            "So[u]rce",
+            "[Z]oom",
+            "Tra[n]slate" if self.can_translate else "",
+            "[H]elp",
+        ]
+        options = "\n" + " ".join(o for o in options if o)
+        options = highlight_keys(options, "cyan_bold", "cyan")
+        return options
+
     def modified(self):
         """Called when the list focus switches to a new status"""
         status, index, count = self.get_focused_status_with_counts()
@@ -100,8 +136,16 @@ class Timeline(urwid.Columns):
         self.draw_status_details(status)
 
     def draw_status_details(self, status):
-        self.status_details = StatusDetails(status, self.is_thread, self.can_translate)
-        self.contents[2] = urwid.Padding(self.status_details, left=1), ("weight", 60, False)
+        opts_footer = urwid.Text(self.get_option_text(status))
+        self.status_details = StatusDetails(self, status, self.is_thread, self.can_translate)
+        self.contents[2] = \
+            (urwid.Padding(\
+                urwid.Frame(body=\
+                ScrollBar(Scrollable(\
+                        self.status_details),\
+                    thumb_char='\u2588', trough_char='\u2591'),\
+                footer=opts_footer), left=1)),\
+            ("weight", 60, False)
 
     def keypress(self, size, key):
         status = self.get_focused_status()
@@ -236,7 +280,7 @@ class Timeline(urwid.Columns):
 
 
 class StatusDetails(urwid.Pile):
-    def __init__(self, status, in_thread, can_translate=False):
+    def __init__(self, timeline, status, in_thread, can_translate=False):
         """
         Parameters
         ----------
@@ -248,6 +292,9 @@ class StatusDetails(urwid.Pile):
         """
         self.in_thread = in_thread
         self.can_translate = can_translate
+        self.timeline = timeline
+        self.status = status
+
         reblogged_by = status.author if status and status.reblog else None
         widget_list = list(self.content_generator(status.original, reblogged_by)
             if status else ())
@@ -265,6 +312,15 @@ class StatusDetails(urwid.Pile):
         yield ("pack", urwid.Text(("yellow", status.author.account)))
         yield ("pack", urwid.Divider())
 
+#        if status.data["account"]["avatar_static"]:
+#            try:
+#                avatar = self.load_image(6, status.data["account"]["avatar_static"])
+#                rows = avatar.size[1]
+#                yield ("pack", urwid.BoxAdapter(ANSIGraphicsWidget(avatar),math.ceil(rows/2)))
+#                yield ("pack", urwid.Divider())
+#            finally:
+#                pass #ignore any error
+
         if status.data["spoiler_text"]:
             yield ("pack", urwid.Text(status.data["spoiler_text"]))
             yield ("pack", urwid.Divider())
@@ -277,24 +333,25 @@ class StatusDetails(urwid.Pile):
             for line in format_content(content):
                 yield ("pack", urwid.Text(highlight_hashtags(line)))
 
-        media = status.data["media_attachments"]
-        if media:
-            for m in media:
-                yield ("pack", urwid.AttrMap(urwid.Divider("-"), "gray"))
-                yield ("pack", urwid.Text([("bold", "Media attachment"), " (", m["type"], ")"]))
-                if m["description"]:
-                    yield ("pack", urwid.Text(m["description"]))
-                yield ("pack", urwid.Text(("link", m["url"])))
+            media = status.data["media_attachments"]
+            if media:
+                for m in media:
+                    yield ("pack", urwid.AttrMap(urwid.Divider("-"), "gray"))
+                    yield ("pack", urwid.Text([("bold", "Media attachment"), " (", m["type"], ")"]))
+                    if m["description"]:
+                        yield ("pack", urwid.Text(m["description"]))
+                    if m["url"]:
+                        yield ("pack", urwid.Text(m["url"]))
 
-        poll = status.data.get("poll")
-        if poll:
-            yield ("pack", urwid.Divider())
-            yield ("pack", self.build_linebox(self.poll_generator(poll)))
+            poll = status.data.get("poll")
+            if poll:
+                yield ("pack", urwid.Divider())
+                yield ("pack", self.build_linebox(self.poll_generator(poll)))
 
-        card = status.data.get("card")
-        if card:
-            yield ("pack", urwid.Divider())
-            yield ("pack", self.build_linebox(self.card_generator(card)))
+            card = status.data.get("card")
+            if card:
+                yield ("pack", urwid.Divider())
+                yield ("pack", self.build_linebox(self.card_generator(card)))
 
         application = status.data.get("application") or {}
         application = application.get("name")
@@ -316,25 +373,8 @@ class StatusDetails(urwid.Pile):
         ]))
 
         # Push things to bottom
-        yield ("weight", 1, urwid.SolidFill(" "))
+        yield ("weight", 1, urwid.BoxAdapter(urwid.SolidFill(" "),1))
 
-        options = [
-            "[B]oost",
-            "[D]elete" if status.is_mine else "",
-            "[F]avourite",
-            "[V]iew",
-            "[T]hread" if not self.in_thread else "",
-            "[L]inks",
-            "[R]eply",
-            "So[u]rce",
-            "[Z]oom",
-            "Tra[n]slate" if self.can_translate else "",
-            "[H]elp",
-        ]
-        options = " ".join(o for o in options if o)
-
-        options = highlight_keys(options, "cyan_bold", "cyan")
-        yield ("pack", urwid.Text(options))
 
     def build_linebox(self, contents):
         contents = urwid.Pile(list(contents))
@@ -349,7 +389,26 @@ class StatusDetails(urwid.Pile):
         if card["description"]:
             yield urwid.Text(card["description"].strip())
             yield urwid.Text("")
+
         yield urwid.Text(("link", card["url"]))
+
+        if card["image"]:
+            if card["image"].lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.svg')):
+                yield urwid.Text("")
+
+                ratio = int(card["height"]) / int(card["width"])
+                rows = math.ceil(20 * ratio)
+
+                img = None
+                if hasattr(self.status,'images'):
+                    img = self.status.images.get(str(hash(card["image"])))
+                if img:
+                    img = resize_image(40, img)
+                    yield("pack", urwid.BoxAdapter(ANSIGraphicsWidget(img),rows))
+                else:
+                    self.timeline._emit("load-image", self.timeline, self.status, card["image"])
+                    yield("pack", urwid.BoxAdapter(urwid.SolidFill(fill_char=" "),rows))
+
 
     def poll_generator(self, poll):
         for idx, option in enumerate(poll["options"]):

--- a/toot/tui/utils.py
+++ b/toot/tui/utils.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 
 from datetime import datetime, timezone
+from PIL import Image
 
 HASHTAG_PATTERN = re.compile(r'(?<!\w)(#\w+)\b')
 
@@ -108,3 +109,11 @@ def parse_content_links(content):
     parser = LinkParser()
     parser.feed(content)
     return parser.links[:]
+
+
+def resize_image(basewidth: int, img: Image) -> Image:
+        wpercent = (basewidth/float(img.size[0]))
+        hsize = int((float(img.size[1])*float(wpercent)))
+        img = img.resize((basewidth,hsize), Image.ANTIALIAS)
+        img = img.convert('RGB')
+        return img


### PR DESCRIPTION
Resubmitted, now with all the files 🙄 

This pull request adds scrolling status details (right-arrow in timeline shifts focus to the status detail window, then up/down arrows allow you to scroll.  left-arrow gets you back to the timeline.)  It also adds ANSI graphics previews for card images.  Images are asychronously loaded.   This could be extended to add previews for media attachments (.png, .jpg, etc.) but there are some threading issues to work out before that can be done properly.
![Screenshot 2022-12-24 194323](https://user-images.githubusercontent.com/3261094/209454933-c057f35d-2ada-45d0-bc51-6636a1845bd4.png)

Note that this does add two new library dependencies; Pillow (PIL) and ansicolors. 