### PR TITLE
Make the status detail key commands more visible

### DIFF
--- a/toot/tui/constants.py
+++ b/toot/tui/constants.py
@@ -36,6 +36,7 @@ PALETTE = [
     ('yellow_bold', 'yellow,bold', ''),
     ('red', 'dark red', ''),
     ('warning', 'light red', ''),
+    ('white_bold', 'white,bold', '')
 ]
 
 VISIBILITY_OPTIONS = [

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -352,7 +352,7 @@ class StatusDetails(urwid.Pile):
         ]
         options = " ".join(o for o in options if o)
 
-        options = highlight_keys(options, "cyan_bold", "cyan")
+        options = highlight_keys(options, "white_bold", "cyan")
         yield ("pack", urwid.Text(options))
 
     def build_linebox(self, contents):


### PR DESCRIPTION
Some terminal color schemes completely eliminate the difference between cyan and cyan-bold colors (all the base16 themes, for instance). This change makes the key letters stand out clearly in bold white.