### PR TITLE
Basic support for followed accounts in TUI

### DIFF
--- a/toot/commands.py
+++ b/toot/commands.py
@@ -280,7 +280,7 @@ def _do_upload(app, user, file, description):
     return api.upload_media(app, user, file, description=description)
 
 
-def _find_account(app, user, account_name):
+def find_account(app, user, account_name):
     if not account_name:
         raise ConsoleError("Empty account name given")
 
@@ -304,25 +304,25 @@ def _find_account(app, user, account_name):
 
 
 def follow(app, user, args):
-    account = _find_account(app, user, args.account)
+    account = find_account(app, user, args.account)
     api.follow(app, user, account['id'])
     print_out("<green>✓ You are now following {}</green>".format(args.account))
 
 
 def unfollow(app, user, args):
-    account = _find_account(app, user, args.account)
+    account = find_account(app, user, args.account)
     api.unfollow(app, user, account['id'])
     print_out("<green>✓ You are no longer following {}</green>".format(args.account))
 
 
 def following(app, user, args):
-    account = _find_account(app, user, args.account)
+    account = find_account(app, user, args.account)
     response = api.following(app, user, account['id'])
     print_acct_list(response)
 
 
 def followers(app, user, args):
-    account = _find_account(app, user, args.account)
+    account = find_account(app, user, args.account)
     response = api.followers(app, user, account['id'])
     print_acct_list(response)
 
@@ -345,25 +345,25 @@ def tags_followed(app, user, args):
 
 
 def mute(app, user, args):
-    account = _find_account(app, user, args.account)
+    account = find_account(app, user, args.account)
     api.mute(app, user, account['id'])
     print_out("<green>✓ You have muted {}</green>".format(args.account))
 
 
 def unmute(app, user, args):
-    account = _find_account(app, user, args.account)
+    account = find_account(app, user, args.account)
     api.unmute(app, user, account['id'])
     print_out("<green>✓ {} is no longer muted</green>".format(args.account))
 
 
 def block(app, user, args):
-    account = _find_account(app, user, args.account)
+    account = find_account(app, user, args.account)
     api.block(app, user, account['id'])
     print_out("<green>✓ You are now blocking {}</green>".format(args.account))
 
 
 def unblock(app, user, args):
-    account = _find_account(app, user, args.account)
+    account = find_account(app, user, args.account)
     api.unblock(app, user, account['id'])
     print_out("<green>✓ {} is no longer blocked</green>".format(args.account))
 
@@ -374,7 +374,7 @@ def whoami(app, user, args):
 
 
 def whois(app, user, args):
-    account = _find_account(app, user, args.account)
+    account = find_account(app, user, args.account)
     print_account(account)
 
 

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from toot import api, config, __version__
 from toot.console import get_default_visibility
 from toot.exceptions import ApiError
+from toot.commands import find_account
 
 from .compose import StatusComposer
 from .constants import PALETTE
@@ -91,7 +92,6 @@ class TUI(urwid.Frame):
         self.app = app
         self.user = user
         self.config = config.load_config()
-
         self.loop = None  # set in `create`
         self.executor = ThreadPoolExecutor(max_workers=1)
         self.timeline_generator = api.home_timeline_generator(app, user, limit=40)
@@ -109,11 +109,13 @@ class TUI(urwid.Frame):
         self.overlay = None
         self.exception = None
         self.can_translate = False
+        self.account = None
 
         super().__init__(self.body, header=self.header, footer=self.footer)
 
     def run(self):
         self.loop.set_alarm_in(0, lambda *args: self.async_load_instance())
+        self.loop.set_alarm_in(0, lambda *args: self.async_load_followed_accounts())
         self.loop.set_alarm_in(0, lambda *args: self.async_load_followed_tags())
         self.loop.set_alarm_in(0, lambda *args: self.async_load_timeline(
             is_initial=True, timeline_name="home"))
@@ -242,7 +244,7 @@ class TUI(urwid.Frame):
             self.loop.set_alarm_in(5, lambda *args: self.footer.clear_message())
             config.save_config(self.config)
 
-        timeline = Timeline(name, statuses, self.can_translate, self.followed_tags)
+        timeline = Timeline(name, statuses, self.can_translate, self.followed_tags, self.followed_accounts)
 
         self.connect_default_timeline_signals(timeline)
         urwid.connect_signal(timeline, "next", _next)
@@ -272,7 +274,7 @@ class TUI(urwid.Frame):
         focus = len(ancestors)
 
         timeline = Timeline("thread", statuses, self.can_translate,
-                            self.followed_tags, focus, is_thread=True)
+                            self.followed_tags, self.followed_accounts, focus, is_thread=True)
 
         self.connect_default_timeline_signals(timeline)
         urwid.connect_signal(timeline, "close", _close)
@@ -339,6 +341,23 @@ class TUI(urwid.Frame):
                 self.can_translate = int(instance["version"][0]) > 3
 
         return self.run_in_thread(_load_instance, done_callback=_done)
+
+    def async_load_followed_accounts(self):
+        def _load_accounts():
+            try:
+                self.account = find_account(self.app, self.user, f'@{self.user.username}@{self.user.instance}')
+                return api.following(self.app, self.user, self.account["id"])
+            except ApiError:
+                # not supported by all Mastodon servers so fail silently if necessary
+                return []
+
+        def _done_accounts(accounts):
+            if len(accounts) > 0:
+                self.followed_accounts = {a["acct"] for a in accounts}
+            else:
+                self.followed_accounts = set()
+
+        self.run_in_thread(_load_accounts, done_callback=_done_accounts)
 
     def async_load_followed_tags(self):
         def _load_tag_list():


### PR DESCRIPTION
In the status detail window, followed accounts are shown in yellow, while unfollowed accounts are shown in grey.
Not sure I love this UI representation (too subtle?) but it can be modified if desired.

Future possibility building on this: an [A]ccount option which will pop up an overlay with choices: Follow/Unfollow/Mute/Block.
