### PR TITLE
fix error during TUI startup

### DIFF
--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -336,7 +336,8 @@ class TUI(urwid.Frame):
                 # this works for Mastodon and Pleroma version strings
                 # Mastodon versions < 4 do not have translation service
                 # Revisit this logic if Pleroma implements translation
-                self.can_translate = int(instance["version"][0]) > 3
+                ch = instance["version"][0]
+                self.can_translate = int(ch) > 3 if ch.isnumeric() else False    
 
         return self.run_in_thread(_load_instance, done_callback=_done)
 

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -337,7 +337,7 @@ class TUI(urwid.Frame):
                 # Mastodon versions < 4 do not have translation service
                 # Revisit this logic if Pleroma implements translation
                 ch = instance["version"][0]
-                self.can_translate = int(ch) > 3 if ch.isnumeric() else False    
+                self.can_translate = int(ch) > 3 if ch.isnumeric() else False
 
         return self.run_in_thread(_load_instance, done_callback=_done)
 


### PR DESCRIPTION
Version check failed when the server sent something other than a number as a version as happened on development version of the gotosocial server.