### PR TITLE
Switch to showing relative times rather than full timestamps in status list

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ sphinx
 sphinx-autobuild
 twine
 wheel
+debugpy

--- a/toot/console.py
+++ b/toot/console.py
@@ -10,6 +10,7 @@ from itertools import chain
 from toot import config, commands, CLIENT_NAME, CLIENT_WEBSITE, __version__
 from toot.exceptions import ApiError, ConsoleError
 from toot.output import print_out, print_err
+from .debugger import initialize_debugger
 
 VISIBILITY_CHOICES = ['public', 'unlisted', 'private', 'direct']
 VISIBILITY_CHOICES_STR = ", ".join(f"'{v}'" for v in VISIBILITY_CHOICES)
@@ -116,6 +117,12 @@ common_args = [
         "action": 'store_true',
         "default": False,
     }),
+    (["--debugger"], {
+        "help": "launch with vscode debugpy",
+        "action": 'store_true',
+        "default": False,
+    }),
+
 ]
 
 # Arguments added to commands which require authentication
@@ -665,6 +672,9 @@ def run_command(app, user, name, args):
 
 
 def main():
+    if "--debugger" in sys.argv:
+        initialize_debugger()
+
     # Enable debug logging if --debug is in args
     if "--debug" in sys.argv:
         filename = os.getenv("TOOT_LOG_FILE")

--- a/toot/debugger.py
+++ b/toot/debugger.py
@@ -1,0 +1,12 @@
+from os import getenv
+
+def initialize_debugger():
+    import multiprocessing
+
+    if multiprocessing.current_process().pid > 1:
+        import debugpy
+
+        debugpy.listen(("0.0.0.0", 9000))
+        print("VSCode Debugger is ready to be attached on port 9000, press F5", flush=True)
+        debugpy.wait_for_client()
+        print("VSCode Debugger is now attached", flush=True)

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -10,6 +10,7 @@ from .utils import highlight_hashtags, parse_datetime, highlight_keys
 from .widgets import SelectableText, SelectableColumns
 from toot.utils import format_content
 from toot.utils.language import language_name
+from toot.tui.utils import time_ago
 
 logger = logging.getLogger("toot")
 
@@ -364,12 +365,13 @@ class StatusDetails(urwid.Pile):
         visibility_color = visibility_colors.get(status.visibility, "gray")
 
         yield ("pack", urwid.Text([
-            ("red", "🠷 ") if status.bookmarked else "",
+            ("blue", f"{status.created_at.strftime('%Y-%m-%d %H:%M')} "),
+            ("red" if status.bookmarked else "gray", "🠷 "),
             ("gray", f"⤶ {status.data['replies_count']} "),
             ("yellow" if status.reblogged else "gray", f"♺ {status.data['reblogs_count']} "),
             ("yellow" if status.favourited else "gray", f"★ {status.data['favourites_count']}"),
             (visibility_color, f" · {visibility}"),
-            ("yellow", f" · Translated from {translated_from} ") if translated_from else "",
+            ("yellow", f" · Translated from {translated_from} " if translated_from else ""),
             ("gray", f" · {application}" if application else ""),
         ]))
 
@@ -418,7 +420,9 @@ class StatusDetails(urwid.Pile):
 
 class StatusListItem(SelectableColumns):
     def __init__(self, status):
-        created_at = status.created_at.strftime("%Y-%m-%d %H:%M")
+        edited = status.data["edited_at"]
+        created_at = time_ago(status.created_at).ljust(3, " ")
+        edited_flag = "*" if edited else " "
         favourited = ("yellow", "★") if status.original.favourited else " "
         reblogged = ("yellow", "♺") if status.original.reblogged else " "
         is_reblog = ("cyan", "♺") if status.reblog else " "
@@ -426,6 +430,7 @@ class StatusListItem(SelectableColumns):
 
         return super().__init__([
             ("pack", SelectableText(("blue", created_at), wrap="clip")),
+            ("pack", urwid.Text(("blue", edited_flag))),
             ("pack", urwid.Text(" ")),
             ("pack", urwid.Text(favourited)),
             ("pack", urwid.Text(" ")),

--- a/toot/tui/utils.py
+++ b/toot/tui/utils.py
@@ -1,4 +1,5 @@
 from html.parser import HTMLParser
+import math
 import os
 import re
 import shutil
@@ -7,6 +8,11 @@ import subprocess
 from datetime import datetime, timezone
 
 HASHTAG_PATTERN = re.compile(r'(?<!\w)(#\w+)\b')
+SECOND = 1
+MINUTE = SECOND * 60
+HOUR = MINUTE * 60
+DAY = HOUR * 24
+WEEK = DAY * 7
 
 
 def parse_datetime(value):
@@ -25,6 +31,28 @@ def parse_datetime(value):
         return dttm.astimezone(timezone.utc)
 
     return dttm.astimezone()
+
+
+def time_ago(value: datetime) -> datetime:
+    now = datetime.now().astimezone()
+    delta = now.timestamp() - value.timestamp()
+
+    if (delta < 1):
+        return "now"
+
+    if (delta < 8 * DAY):
+        if (delta < MINUTE):
+            return f"{math.floor(delta / SECOND)}".rjust(2, " ") + "s"
+        if (delta < HOUR):
+            return f"{math.floor(delta / MINUTE)}".rjust(2, " ") + "m"
+        if (delta < DAY):
+            return f"{math.floor(delta / HOUR)}".rjust(2, " ") + "h"
+        return f"{math.floor(delta / DAY)}".rjust(2, " ") + "d"
+
+    if (delta < 53 * WEEK):  # not exactly correct but good enough as a boundary
+        return f"{math.floor(delta / WEEK)}".rjust(2, " ") + "w"
+
+    return ">1y"
 
 
 def highlight_keys(text, high_attr, low_attr=""):


### PR DESCRIPTION
You now see the seconds, minutes, days, or weeks since the toot was created, rather than the full timestamp.  A star is added to the time of toots that have been edited.

_The full timestamp is now shown in the status detail pane._

This change frees up 6 columns. These columns can be used to implement follow-on UI changes:
Scrollbar in status list, and focus boxes around the status list and status detail. (Box follows focus.)

![image](https://user-images.githubusercontent.com/3261094/213821830-3bc9b197-0d25-4e75-8587-e3c4db6839e9.png)
