### PR TITLE
Status list now shows relative time created, rather than timestamp

### DIFF
--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -10,6 +10,7 @@ from .utils import highlight_hashtags, parse_datetime, highlight_keys
 from .widgets import SelectableText, SelectableColumns
 from toot.utils import format_content
 from toot.utils.language import language_name
+from toot.tui.utils import time_ago
 
 logger = logging.getLogger("toot")
 
@@ -364,12 +365,13 @@ class StatusDetails(urwid.Pile):
         visibility_color = visibility_colors.get(status.visibility, "gray")
 
         yield ("pack", urwid.Text([
-            ("red", "🠷 ") if status.bookmarked else "",
+            ("blue", f"{status.created_at.strftime('%Y-%m-%d %H:%M')} "),
+            ("red" if status.bookmarked else "gray", "🠷 "),
             ("gray", f"⤶ {status.data['replies_count']} "),
             ("yellow" if status.reblogged else "gray", f"♺ {status.data['reblogs_count']} "),
             ("yellow" if status.favourited else "gray", f"★ {status.data['favourites_count']}"),
             (visibility_color, f" · {visibility}"),
-            ("yellow", f" · Translated from {translated_from} ") if translated_from else "",
+            ("yellow", f" · Translated from {translated_from} " if translated_from else ""),
             ("gray", f" · {application}" if application else ""),
         ]))
 
@@ -418,7 +420,9 @@ class StatusDetails(urwid.Pile):
 
 class StatusListItem(SelectableColumns):
     def __init__(self, status):
-        created_at = status.created_at.strftime("%Y-%m-%d %H:%M")
+        edited = status.data["edited_at"]
+        created_at = time_ago(status.created_at).ljust(3, " ")
+        edited_flag = "*" if edited else " "
         favourited = ("yellow", "★") if status.original.favourited else " "
         reblogged = ("yellow", "♺") if status.original.reblogged else " "
         is_reblog = ("cyan", "♺") if status.reblog else " "
@@ -426,6 +430,7 @@ class StatusListItem(SelectableColumns):
 
         return super().__init__([
             ("pack", SelectableText(("blue", created_at), wrap="clip")),
+            ("pack", urwid.Text(("blue", edited_flag))),
             ("pack", urwid.Text(" ")),
             ("pack", urwid.Text(favourited)),
             ("pack", urwid.Text(" ")),

--- a/toot/tui/utils.py
+++ b/toot/tui/utils.py
@@ -1,4 +1,5 @@
 from html.parser import HTMLParser
+import math
 import os
 import re
 import shutil
@@ -7,6 +8,11 @@ import subprocess
 from datetime import datetime, timezone
 
 HASHTAG_PATTERN = re.compile(r'(?<!\w)(#\w+)\b')
+SECOND = 1
+MINUTE = SECOND * 60
+HOUR = MINUTE * 60
+DAY = HOUR * 24
+WEEK = DAY * 7
 
 
 def parse_datetime(value):
@@ -25,6 +31,28 @@ def parse_datetime(value):
         return dttm.astimezone(timezone.utc)
 
     return dttm.astimezone()
+
+
+def time_ago(value: datetime) -> datetime:
+    now = datetime.now().astimezone()
+    delta = now.timestamp() - value.timestamp()
+
+    if (delta < 1):
+        return "now"
+
+    if (delta < 8 * DAY):
+        if (delta < MINUTE):
+            return f"{math.floor(delta / SECOND)}".rjust(2, " ") + "s"
+        if (delta < HOUR):
+            return f"{math.floor(delta / MINUTE)}".rjust(2, " ") + "m"
+        if (delta < DAY):
+            return f"{math.floor(delta / HOUR)}".rjust(2, " ") + "h"
+        return f"{math.floor(delta / DAY)}".rjust(2, " ") + "d"
+
+    if (delta < 53 * WEEK):  # not exactly correct but good enough as a boundary
+        return f"{math.floor(delta / WEEK)}".rjust(2, " ") + "w"
+
+    return ">1y"
 
 
 def highlight_keys(text, high_attr, low_attr=""):


### PR DESCRIPTION
This is similar to how the stock Mastodon web client displays toot created_at times.  It's easier for users to interpret. A star is added for toots that have been edited (again, like the Mastodon web client.)   _The full timestamp is now displayed in the status detail pane_

This allows us to show the created_time delta in 4 columns rather than 10.  We can use those columns to add more UI features like a scrollbar for the status list, and a focus box that moves between the status list and status detail pane.

Here is what the UI looks like with the change:
![image](https://user-images.githubusercontent.com/3261094/213823015-6f91b9d8-86ae-44eb-8fee-f9af8c7c189f.png)

Here is a preview of a future UI with status list scrollbar and focus box (NOT part of this pull request!).  Focus box is shown in both panes at once because I haven't figured out how to trigger on pane focus change (suggestions welcome!)

![image](https://user-images.githubusercontent.com/3261094/213823138-9a72392a-13b0-48d8-a5a8-252ec4617d39.png)


