### PR TITLE
Account feature - show account of current status author (/reblogger)

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -357,6 +357,10 @@ def followed_tags(app, user):
     return _get_response_list(app, user, path)
 
 
+def whois(app, user, account):
+    return http.get(app, user, f'/api/v1/accounts/{account}').json()
+
+
 def mute(app, user, account):
     return _account_action(app, user, account, 'mute')
 

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -11,7 +11,7 @@ from .compose import StatusComposer
 from .constants import PALETTE
 from .entities import Status
 from .overlays import ExceptionStackTrace, GotoMenu, Help, StatusSource, StatusLinks, StatusZoom
-from .overlays import StatusDeleteConfirmation
+from .overlays import StatusDeleteConfirmation, Account
 from .timeline import Timeline
 from .utils import parse_content_links, show_media
 
@@ -175,6 +175,9 @@ class TUI(urwid.Frame):
         return future
 
     def connect_default_timeline_signals(self, timeline):
+        def _account(timeline, account_id):
+            self.show_account(account_id)
+
         def _compose(*args):
             self.show_compose()
 
@@ -203,6 +206,7 @@ class TUI(urwid.Frame):
         def _clear(*args):
             self.clear_screen()
 
+        urwid.connect_signal(timeline, "account", _account)
         urwid.connect_signal(timeline, "bookmark", self.async_toggle_bookmark)
         urwid.connect_signal(timeline, "compose", _compose)
         urwid.connect_signal(timeline, "delete", _delete)
@@ -503,6 +507,13 @@ class TUI(urwid.Frame):
 
         self.footer.set_message("Status posted {} \\o/".format(status.id))
         self.close_overlay()
+
+    def show_account(self, account_id):
+        account = api.whois(self.app, self.user, account_id)
+        self.open_overlay(
+            widget=Account(account),
+            title="Account",
+        )
 
     def async_toggle_favourite(self, timeline, status):
         def _favourite():

--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -221,6 +221,17 @@ class Account(urwid.ListBox):
         yield urwid.Text([("ID: "), ("green", f"{account['id']}")])
         yield urwid.Text([("Since: "), ("green", f"{account['created_at'][:10]}")])
         yield urwid.Divider()
+
+        if account["bot"]:
+            yield urwid.Text([("Bot: "), ("green", "True \N{robot face}")])
+            yield urwid.Divider()
+        if account["locked"]:
+            yield urwid.Text([("Locked: "), ("warning", "True \N{lock}")])
+            yield urwid.Divider()
+        if "suspended" in account and account["suspended"]:
+            yield urwid.Text([("Suspended: "), ("warning", "True \N{cross mark}")])
+            yield urwid.Divider()
+
         yield urwid.Text([("Followers: "), ("yellow", f"{account['followers_count']}")])
         yield urwid.Text([("Following: "), ("yellow", f"{account['following_count']}")])
         yield urwid.Text([("Statuses: "), ("yellow", f"{account['statuses_count']}")])

--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -240,7 +240,7 @@ class Account(urwid.ListBox):
             for field in account["fields"]:
                 name = field["name"].title()
                 yield urwid.Divider()
-                yield urwid.Text([("yellow", f"{name}"), (":")])
+                yield urwid.Text([("yellow", f"{name.rstrip(':')}"), (":")])
                 for line in format_content(field["value"]):
                     yield urwid.Text(highlight_hashtags(line, followed_tags=set()))
                 if field["verified_at"]:

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -21,6 +21,7 @@ class Timeline(urwid.Columns):
     Displays a list of statuses to the left, and status details on the right.
     """
     signals = [
+        "account",       # Display account info and actions
         "close",         # Close thread
         "compose",       # Compose a new toot
         "delete",        # Delete own status
@@ -102,6 +103,7 @@ class Timeline(urwid.Columns):
             return None
 
         options = [
+            "[A]ccount" if not status.is_mine else "",
             "[B]oost",
             "[D]elete" if status.is_mine else "",
             "B[o]okmark",
@@ -168,6 +170,10 @@ class Timeline(urwid.Columns):
             count = len(self.statuses)
             if index >= count:
                 self._emit("next")
+
+        if key in ("a", "A"):
+            self._emit("account", status.data['account']['id'])
+            return
 
         if key in ("b", "B"):
             self._emit("reblog", status)


### PR DESCRIPTION
Right now it's roughly at feature parity with `toot whois`

It can be extended to add commands (follow/unfollow, mute/unmute, etc.) if that's the right place to put those commands.  It is not tied strongly to a status item, so can be invoked from elsewhere, all that's needed as input is an account ID.

![image](https://user-images.githubusercontent.com/3261094/216490957-500fc7a1-88d0-47de-ad98-f54aa2256003.png)
