### PR TITLE
Changed bookmark symbol from unicode glyph to 'b'

### DIFF
--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -373,7 +373,7 @@ class StatusDetails(urwid.Pile):
 
         yield ("pack", urwid.Text([
             ("blue", f"{status.created_at.strftime('%Y-%m-%d %H:%M')} "),
-            ("red" if status.bookmarked else "gray", "🠷 "),
+            ("red" if status.bookmarked else "gray", "b "),
             ("gray", f"⤶ {status.data['replies_count']} "),
             ("yellow" if status.reblogged else "gray", f"♺ {status.data['reblogs_count']} "),
             ("yellow" if status.favourited else "gray", f"★ {status.data['favourites_count']}"),


### PR DESCRIPTION
The glyph previously used '🠷' is interpreted with different widths on different terminal emulators (i.e. xterm gets it wrong) This results in visual glitches in the status detail area and especially in the scrollbar when visible.  Changing it to a standard ASCII 'b' fixes all these issues.

Example of the glitch.  You can also see in this example that xterm doesn't render the 🠷 character at all, this is a shortcoming of the emulator itself (doesn't do fallback font substitution). 

![image](https://user-images.githubusercontent.com/3261094/216794306-60aa46e7-1d61-4053-bc4f-94e0b74bf1e6.png)
