### PR TITLE
Account overlay - don't allow mute/block/unfollow own account

### DIFF
--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -224,16 +224,19 @@ class Account(urwid.ListBox):
             yield Button(f"Confirm {self.last_action}", on_press=take_action, user_data=self)
             yield Button("Cancel", on_press=cancel_action, user_data=self)
         else:
-            if relationship['requested']:
-                yield urwid.Text(("light grey", "< Follow request is pending >"))
+            if self.user.username == account["acct"]:
+                yield urwid.Text(("light gray", "This is your account"))
             else:
-                yield Button("Unfollow" if relationship['following'] else "Follow",
-                on_press=confirm_action, user_data=self)
+                if relationship['requested']:
+                    yield urwid.Text(("light gray", "< Follow request is pending >"))
+                else:
+                    yield Button("Unfollow" if relationship['following'] else "Follow",
+                    on_press=confirm_action, user_data=self)
 
-            yield Button("Unmute" if relationship['muting'] else "Mute",
-                on_press=confirm_action, user_data=self)
-            yield Button("Unblock" if relationship['blocking'] else "Block",
-                on_press=confirm_action, user_data=self)
+                yield Button("Unmute" if relationship['muting'] else "Mute",
+                    on_press=confirm_action, user_data=self)
+                yield Button("Unblock" if relationship['blocking'] else "Block",
+                    on_press=confirm_action, user_data=self)
 
         yield urwid.Divider("─")
         yield urwid.Divider()


### PR DESCRIPTION
Realized that it doesn't make sense to offer the user the option to follow, mute, or block their own account  🙄 

![image](https://user-images.githubusercontent.com/3261094/220499495-bba64278-85a2-4bfc-b5eb-16a0278f770e.png)
