### PR TITLE
Basic support for viewing Status and Mention notifs as a timeline

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -290,8 +290,11 @@ def _timeline_generator(app, user, path, params=None):
 def _notif_timeline_generator(app, user, path, params=None):
     while path:
         response = http.get(app, user, path, params)
-        notif = response.json()
-        statuses = [n['status'] for n in notif]
+        notification = response.json()
+        statuses = []
+        for n in notification:
+            if n['status']:
+                statuses.append(n['status'])
         yield statuses
         path = _get_next_path(response.headers)
 

--- a/toot/api.py
+++ b/toot/api.py
@@ -287,6 +287,15 @@ def _timeline_generator(app, user, path, params=None):
         path = _get_next_path(response.headers)
 
 
+def _notif_timeline_generator(app, user, path, params=None):
+    while path:
+        response = http.get(app, user, path, params)
+        notif = response.json()
+        statuses = [n['status'] for n in notif]
+        yield statuses
+        path = _get_next_path(response.headers)
+
+
 def home_timeline_generator(app, user, limit=20):
     path = "/api/v1/timelines/home"
     params = {"limit": limit}
@@ -309,6 +318,13 @@ def bookmark_timeline_generator(app, user, limit=20):
     path = '/api/v1/bookmarks'
     params = {'limit': limit}
     return _timeline_generator(app, user, path, params)
+
+
+def notification_timeline_generator(app, user, limit=20):
+    # exclude all but mentions and statuses
+    exclude_types = ["follow", "favourite", "reblog", "poll", "follow_request"]
+    params = {"exclude_types[]": exclude_types, "limit": limit}
+    return _notif_timeline_generator(app, user, '/api/v1/notifications', params)
 
 
 def timeline_list_generator(app, user, list_id, limit=20):

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -438,13 +438,14 @@ class TUI(urwid.Frame):
             lambda x, local: self.goto_public_timeline(local))
         urwid.connect_signal(menu, "bookmark_timeline",
             lambda x, local: self.goto_bookmarks())
-
+        urwid.connect_signal(menu, "notification_timeline",
+            lambda x, local: self.goto_notifications())
         urwid.connect_signal(menu, "hashtag_timeline",
             lambda x, tag, local: self.goto_tag_timeline(tag, local=local))
 
         self.open_overlay(menu, title="Go to", options=dict(
             align="center", width=("relative", 60),
-            valign="middle", height=10 + len(user_timelines),
+            valign="middle", height=11 + len(user_timelines),
         ))
 
     def show_help(self):
@@ -472,6 +473,12 @@ class TUI(urwid.Frame):
         self.timeline_generator = api.bookmark_timeline_generator(
             self.app, self.user, limit=40)
         promise = self.async_load_timeline(is_initial=True, timeline_name="bookmarks")
+        promise.add_done_callback(lambda *args: self.close_overlay())
+
+    def goto_notifications(self):
+        self.timeline_generator = api.notification_timeline_generator(
+            self.app, self.user, limit=40)
+        promise = self.async_load_timeline(is_initial=True, timeline_name="notifications")
         promise.add_done_callback(lambda *args: self.close_overlay())
 
     def goto_tag_timeline(self, tag, local):

--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -100,6 +100,7 @@ class GotoMenu(urwid.ListBox):
         "public_timeline",
         "hashtag_timeline",
         "bookmark_timeline",
+        "notification_timeline",
     ]
 
     def __init__(self, user_timelines):
@@ -125,6 +126,9 @@ class GotoMenu(urwid.ListBox):
         def _bookmarks(button):
             self._emit("bookmark_timeline", False)
 
+        def _notifications(button):
+            self._emit("notification_timeline", False)
+
         def _hashtag(local):
             hashtag = self.get_hashtag()
             if hashtag:
@@ -147,6 +151,7 @@ class GotoMenu(urwid.ListBox):
         yield Button("Local public timeline", on_press=_local_public)
         yield Button("Global public timeline", on_press=_global_public)
         yield Button("Bookmarks", on_press=_bookmarks)
+        yield Button("Notifications", on_press=_notifications)
         yield urwid.Divider()
         yield self.hash_edit
         yield Button("Local hashtag timeline", on_press=lambda x: _hashtag(True))


### PR DESCRIPTION
Now the Goto Menu has a < Notifications > button. This will load your Status and Mention notifications as a standard timeline for viewing.

![image](https://user-images.githubusercontent.com/3261094/221333607-1a1400f9-c481-4234-8deb-5d7d6373ddfb.png)

