### PR TITLE
Browse other servers' public local timelines

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -266,6 +266,11 @@ def context(app, user, status_id):
     return http.get(app, user, url).json()
 
 
+def anon_context(instance, status_id):
+    url = f"https://{instance}/api/v1/statuses/{status_id}/context"
+    return http.anon_get(url).json()
+
+
 def reblogged_by(app, user, status_id):
     url = f"/api/v1/statuses/{status_id}/reblogged_by"
     return http.get(app, user, url).json()

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -461,6 +461,7 @@ class TUI(urwid.Frame):
         promise = self.async_load_timeline(is_initial=True, timeline_name="home")
         promise.add_done_callback(lambda *args: self.close_overlay())
 
+<<<<<<< HEAD
     def goto_public_timeline(self, local, instance=None):
         if instance:
             self.timeline_generator = api.anon_public_timeline_generator(
@@ -473,6 +474,11 @@ class TUI(urwid.Frame):
             is_initial=True,
             timeline_name=instance if instance else "public",
             instance=instance)
+
+    def goto_public_timeline(self, local):
+        self.timeline_generator = api.public_timeline_generator(
+            self.app, self.user, local=local, limit=40)
+        promise = self.async_load_timeline(is_initial=True, timeline_name="local public" if local else "global public")
         promise.add_done_callback(lambda *args: self.close_overlay())
 
     def goto_bookmarks(self):
@@ -695,8 +701,20 @@ class TUI(urwid.Frame):
 
         elif key == ',':
             if not self.overlay:
-                self.timeline_generator = api.home_timeline_generator(
-                    self.app, self.user, limit=40)
+                if self.timeline.name == 'bookmarks':
+                    return  # no point in refreshing the bookmarks timeline
+                if self.timeline.name.startswith("#"):
+                    self.timeline_generator = api.tag_timeline_generator(
+                        self.app, self.user, self.timeline.name[1:], limit=40)
+                else:
+                    if self.timeline.name.endswith('public'):
+                        self.timeline_generator = api.public_timeline_generator(
+                            self.app, self.user, local=self.timeline.name.startswith('local'), limit=40)
+                    else:
+                        # default to home timeline
+                        self.timeline_generator = api.home_timeline_generator(
+                            self.app, self.user, limit=40)
+
                 self.async_load_timeline(is_initial=True, timeline_name=self.timeline.name)
 
         elif key == 'esc':

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -7,7 +7,7 @@ from toot import api, config, __version__
 from toot.console import get_default_visibility
 from toot.exceptions import ApiError
 
-from toot.commands import _find_account  # fixme this is not clean
+from toot.commands import _find_account  # FIXME: this is not clean
 from .compose import StatusComposer
 from .constants import PALETTE
 from .entities import Status
@@ -714,14 +714,13 @@ class TUI(urwid.Frame):
                     # timelines with . in the name are server.domain; foreign servers
                     self.timeline_generator = api.anon_public_timeline_generator(
                         instance=self.timeline.name, local=True, limit=40)
+                elif self.timeline.name.endswith('public'):
+                    self.timeline_generator = api.public_timeline_generator(
+                        self.app, self.user, local=self.timeline.name.startswith('local'), limit=40)
                 else:
-                    if self.timeline.name.endswith('public'):
-                        self.timeline_generator = api.public_timeline_generator(
-                            self.app, self.user, local=self.timeline.name.startswith('local'), limit=40)
-                    else:
-                        # default to home timeline
-                        self.timeline_generator = api.home_timeline_generator(
-                            self.app, self.user, limit=40)
+                    # default to home timeline
+                    self.timeline_generator = api.home_timeline_generator(
+                        self.app, self.user, limit=40)
 
                 self.async_load_timeline(is_initial=True, timeline_name=self.timeline.name)
 

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -710,6 +710,10 @@ class TUI(urwid.Frame):
                 if self.timeline.name.startswith("#"):
                     self.timeline_generator = api.tag_timeline_generator(
                         self.app, self.user, self.timeline.name[1:], limit=40)
+                elif '.' in self.timeline.name:
+                    # timelines with . in the name are server.domain; foreign servers
+                    self.timeline_generator = api.anon_public_timeline_generator(
+                        instance=self.timeline.name, local=True, limit=40)
                 else:
                     if self.timeline.name.endswith('public'):
                         self.timeline_generator = api.public_timeline_generator(

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -529,7 +529,7 @@ class TUI(urwid.Frame):
             spoiler_text=warning,
             visibility=visibility,
             in_reply_to_id=in_reply_to_id)
-        status = self.make_status(data)
+        status = self.make_status(data, None)
 
         # TODO: fetch new items from the timeline?
 
@@ -561,7 +561,7 @@ class TUI(urwid.Frame):
             # Create a new Status with flipped favourited flag
             new_data = status.data
             new_data["favourited"] = not status.favourited
-            new_status = self.make_status(new_data)
+            new_status = self.make_status(new_data, None)
             timeline.update_status(new_status)
 
         self.run_in_thread(
@@ -582,7 +582,7 @@ class TUI(urwid.Frame):
             # Create a new Status with flipped reblogged flag
             new_data = status.data
             new_data["reblogged"] = not status.reblogged
-            new_status = self.make_status(new_data)
+            new_status = self.make_status(new_data, None)
             timeline.update_status(new_status)
 
         # Check if status is rebloggable
@@ -643,7 +643,7 @@ class TUI(urwid.Frame):
             # Create a new Status with flipped bookmarked flag
             new_data = status.data
             new_data["bookmarked"] = not status.bookmarked
-            new_status = self.make_status(new_data)
+            new_status = self.make_status(new_data, None)
             timeline.update_status(new_status)
 
         self.run_in_thread(

--- a/toot/tui/entities.py
+++ b/toot/tui/entities.py
@@ -20,7 +20,7 @@ class Status:
         If a reblog, the reblogged status, otherwise self.
     """
 
-    def __init__(self, data, is_mine, default_instance):
+    def __init__(self, data, is_mine, default_instance, timeline_instance):
         """
         Parameters
         ----------
@@ -35,11 +35,15 @@ class Status:
             The domain of the instance into which the user is logged in. Used to
             create fully qualified account names for users on the same instance.
             Mastodon only populates the name, not the domain.
+
+        timeline_instance : str
+            Optional. The domain of the instance associated with the timeline
         """
 
         self.data = data
         self.is_mine = is_mine
         self.default_instance = default_instance
+        self.timeline_instance = timeline_instance
 
         # This can be toggled by the user
         self.show_sensitive = False
@@ -75,16 +79,18 @@ class Status:
         reblog_is_mine = self.is_mine and (
             self.data["account"]["acct"] == reblog["account"]["acct"]
         )
-        return Status(reblog, reblog_is_mine, self.default_instance)
+        return Status(reblog, reblog_is_mine, self.default_instance, self.timeline_instance)
 
     def _get_author(self):
         acct = self.data['account']['acct']
-        acct = acct if "@" in acct else "{}@{}".format(acct, self.default_instance)
+        acct = acct if "@" in acct else "{}@{}".format(acct,
+            self.timeline_instance if self.timeline_instance else self.default_instance)
         return Author(acct, self.data['account']['display_name'], self.data['account']['username'])
 
     def _get_account(self):
         acct = self.data['account']['acct']
-        return acct if "@" in acct else "{}@{}".format(acct, self.default_instance)
+        return acct if "@" in acct else "{}@{}".format(acct,
+            self.timeline_instance if self.timeline_instance else self.default_instance)
 
     def __repr__(self):
         return "<Status id={} account={}>".format(self.id, self.account)

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -179,7 +179,13 @@ class Timeline(urwid.Columns):
                 self._emit("next")
 
         if key in ("a", "A"):
-            self._emit("account", status.original.data['account']['id'])
+            # if we're on a foreign server's public timeline, server-local account names
+            # don't have the @server.domain, so add it.
+            if '.' in self.name and '@' not in self.name:
+                account_name = status.original.data['account']['acct'] + "@" + self.name
+            else:
+                account_name = status.original.data['account']['acct']
+            self._emit("account", account_name)
             return
 
         if key in ("b", "B"):

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -44,10 +44,11 @@ class Timeline(urwid.Columns):
     ]
 
     def __init__(self, name, statuses, can_translate, followed_tags=[], focus=0, is_thread=False):
-        self.name = name
         # detect if this timeline is from a foreign server by looking for a '.' in the name
         # foreign server timelines are in server.domain format.
         self.foreign = '.' in name
+        self.name = f"{name} thread" if is_thread and self.foreign else name
+
         self.is_thread = is_thread
         self.statuses = statuses
         # translation not available when browsing a foreign server
@@ -424,24 +425,24 @@ class StatusDetails(urwid.Pile):
         yield urwid.Text(("link", card["url"]))
 
     def poll_generator(self, poll):
-        for idx, option in enumerate(poll["options"]):
-            perc = (round(100 * option["votes_count"] / poll["votes_count"])
-                if poll["votes_count"] else 0)
+        for idx, option in enumerate(poll.get("options")):
+            perc = (round(100 * option.get("votes_count") / poll.get("votes_count"))
+                if poll.get("votes_count") else 0)
 
-            if poll["voted"] and poll["own_votes"] and idx in poll["own_votes"]:
+            if poll.get("voted") and poll.get("own_votes") and idx in poll["own_votes"]:
                 voted_for = " ✓"
             else:
                 voted_for = ""
 
-            yield urwid.Text(option["title"] + voted_for)
+            yield urwid.Text(option.get("title") + voted_for)
             yield urwid.ProgressBar("", "poll_bar", perc)
 
-        status = "Poll · {} votes".format(poll["votes_count"])
+        status = "Poll · {} votes".format(poll.get("votes_count"))
 
-        if poll["expired"]:
+        if poll.get("expired"):
             status += " · Closed"
 
-        if poll["expires_at"]:
+        if poll.get("expires_at"):
             expires_at = parse_datetime(poll["expires_at"]).strftime("%Y-%m-%d %H:%M")
             status += " · Closes on {}".format(expires_at)
 


### PR DESCRIPTION
Here's an interesting feature ~~that's about 3/4 done (so this is another draft).~~

With this PR you can select another Mastodon server and browse its local public timeline, anonymously.  For example, if you're interested in the Rust language, [hachyderm.io](https://hachyderm.io) has a lot of relevant content.

![image](https://user-images.githubusercontent.com/3261094/221733727-222cbe0d-bb4f-400e-b9c2-5a0bd31cd0c7.png)

While you browse, you're still logged in to your active account on your home server.

![image](https://user-images.githubusercontent.com/3261094/221733791-777b0d17-1e97-4ffd-8a57-8bb606837923.png)


The previously reported bugs have been squashed, per my limited testing.