### PR TITLE
Inherit visibility when replying in TUI

### DIFF
--- a/toot/tui/compose.py
+++ b/toot/tui/compose.py
@@ -33,7 +33,9 @@ class StatusComposer(urwid.Frame):
         self.cw_remove_button = Button("Remove content warning",
             on_press=self.remove_content_warning)
 
-        self.visibility = get_default_visibility()
+        self.visibility = (
+            in_reply_to.visibility if in_reply_to else get_default_visibility()
+        )
         self.visibility_button = Button("Visibility: {}".format(self.visibility),
             on_press=self.choose_visibility)
 


### PR DESCRIPTION
When replying to a toot, the visibility gets set to default: if the toot has a direct visibility, the visibility in reply will be changed to the default one, whereas it should stay in direct mode.

This fixes the issue #331. 