### PR TITLE
Add cop[y] status feature - copies status text to clipboard

### DIFF
--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -206,6 +206,7 @@ class Help(urwid.Padding):
         yield urwid.Text(h("  [L] - Show the status links"))
         yield urwid.Text(h("  [U] - Show the status data in JSON as received from the server"))
         yield urwid.Text(h("  [V] - Open status in default browser"))
+        yield urwid.Text(h("  [Y] - Copy status to clipboard"))
         yield urwid.Text(h("  [Z] - Open status in scrollable popup window"))
         yield urwid.Divider()
         yield urwid.Text(("bold", "Links"))

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -41,6 +41,7 @@ class Timeline(urwid.Columns):
         "save",          # Save current timeline
         "zoom",          # Open status in scrollable popup window
         "clear-screen",  # Clear the screen (used internally)
+        "copy-status",   # Copy status to clipboard
     ]
 
     def __init__(self, name, statuses, can_translate, followed_tags=[], focus=0, is_thread=False):
@@ -120,6 +121,7 @@ class Timeline(urwid.Columns):
             "So[u]rce",
             "[Z]oom",
             "Tra[n]slate" if self.can_translate else "",
+            "Cop[y]",
             "[H]elp",
         ]
         options = "\n" + " ".join(o for o in options if o)
@@ -259,6 +261,10 @@ class Timeline(urwid.Columns):
             poll = status.original.data.get("poll")
             if poll and not poll["expired"]:
                 self._emit("poll", status)
+            return
+
+        if key in ("y", "Y"):
+            self._emit("copy-status", status)
             return
 
         return super().keypress(size, key)

--- a/toot/tui/utils.py
+++ b/toot/tui/utils.py
@@ -1,3 +1,5 @@
+import base64
+import urwid
 from html.parser import HTMLParser
 import math
 import os
@@ -144,3 +146,20 @@ def parse_content_links(content):
     parser = LinkParser()
     parser.feed(content)
     return parser.links[:]
+
+
+def copy_to_clipboard(screen: urwid.raw_display.Screen, text: str):
+    """ copy text to clipboard using OSC 52
+    This escape sequence is documented
+    here https://iterm2.com/documentation-escape-codes.html
+    It has wide support - XTerm, Windows Terminal,
+    Kitty, iTerm2, others. Some terminals may require a setting to be
+    enabled in order to use OSC 52 clipboard functions.
+    """
+
+    text_bytes = text.encode("utf-8")
+    b64_bytes = base64.b64encode(text_bytes)
+    b64_text = b64_bytes.decode("utf-8")
+
+    screen.write(f"\033]52;c;{b64_text}\a")
+    screen.flush()


### PR DESCRIPTION
This relies on the OSC 52 terminal feature, which is widely supported (Windows Terminal, iTerm2, XTerm, Kitty, others). Basic support for copying the entire status text content is in place- but this can be improved in future by removing HTML tags, adding URL links, author info etc. as is done for status messages in the `toot timeline console command.