### PR TITLE
Add support for custom instance domains

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,7 @@ def test_create_app(mock_post):
         'client_secret': 'bar',
     })
 
-    create_app('bigfish.software')
+    create_app('https://bigfish.software')
 
     mock_post.assert_called_once_with('https://bigfish.software/api/v1/apps', json={
         'website': CLIENT_WEBSITE,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -13,17 +13,18 @@ def test_register_app(monkeypatch):
         assert app.client_secret == "cs"
 
     monkeypatch.setattr(api, 'create_app', retval(app_data))
-    monkeypatch.setattr(api, 'get_instance', retval({"title": "foo", "version": "1"}))
+    monkeypatch.setattr(api, 'get_instance', retval({"title": "foo", "version": "1", "uri": "bezdomni.net"}))
     monkeypatch.setattr(config, 'save_app', assert_app)
 
-    app = auth.register_app("foo.bar")
+    app = auth.register_app("foo.bar", "https://foo.bar")
     assert_app(app)
 
 
 def test_create_app_from_config(monkeypatch):
     """When there is saved config, it's returned"""
     monkeypatch.setattr(config, 'load_app', retval("loaded app"))
-    app = auth.create_app_interactive("bezdomni.net")
+    monkeypatch.setattr(api, 'get_instance', retval({"title": "foo", "version": "1", "uri": "bezdomni.net"}))
+    app = auth.create_app_interactive("https://bezdomni.net")
     assert app == 'loaded app'
 
 
@@ -31,6 +32,7 @@ def test_create_app_registered(monkeypatch):
     """When there is no saved config, a new app is registered"""
     monkeypatch.setattr(config, 'load_app', retval(None))
     monkeypatch.setattr(auth, 'register_app', retval("registered app"))
+    monkeypatch.setattr(api, 'get_instance', retval({"title": "foo", "version": "1", "uri": "bezdomni.net"}))
 
     app = auth.create_app_interactive("bezdomni.net")
     assert app == 'registered app'

--- a/toot/__init__.py
+++ b/toot/__init__.py
@@ -5,7 +5,7 @@ __version__ = '0.35.0'
 App = namedtuple('App', ['instance', 'base_url', 'client_id', 'client_secret'])
 User = namedtuple('User', ['instance', 'username', 'access_token'])
 
-DEFAULT_INSTANCE = 'mastodon.social'
+DEFAULT_INSTANCE = 'https://mastodon.social'
 
 CLIENT_NAME = 'toot - a Mastodon CLI client'
 CLIENT_WEBSITE = 'https://github.com/ihabunek/toot'

--- a/toot/api.py
+++ b/toot/api.py
@@ -28,8 +28,8 @@ def _tag_action(app, user, tag_name, action):
     return http.post(app, user, url).json()
 
 
-def create_app(domain, scheme='https'):
-    url = f"{scheme}://{domain}/api/v1/apps"
+def create_app(base_url):
+    url = f"{base_url}/api/v1/apps"
 
     json = {
         'client_name': CLIENT_NAME,
@@ -504,6 +504,6 @@ def clear_notifications(app, user):
     http.post(app, user, '/api/v1/notifications/clear')
 
 
-def get_instance(domain, scheme="https"):
-    url = f"{scheme}://{domain}/api/v1/instance"
+def get_instance(base_url):
+    url = f"{base_url}/api/v1/instance"
     return http.anon_get(url).json()

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -336,7 +336,7 @@ class TUI(urwid.Frame):
         See: https://github.com/mastodon/mastodon/issues/19328
         """
         def _load_instance():
-            return api.get_instance(self.app.instance)
+            return api.get_instance(self.app.base_url)
 
         def _done(instance):
             if "max_toot_chars" in instance:

--- a/toot/utils/__init__.py
+++ b/toot/utils/__init__.py
@@ -160,3 +160,29 @@ def _use_existing_tmp_file(tmp_path) -> bool:
 def drop_empty_values(data: Dict) -> Dict:
     """Remove keys whose values are null"""
     return {k: v for k, v in data.items() if v is not None}
+
+
+def args_get_instance(instance, scheme, default=None):
+    if not instance:
+        return default
+
+    if scheme == "http":
+        _warn_scheme_deprecated()
+
+    if instance.startswith("http"):
+        return instance.rstrip("/")
+    else:
+        return f"{scheme}://{instance}"
+
+
+def _warn_scheme_deprecated():
+    from toot.output import print_err
+
+    print_err("\n".join([
+        "--disable-https flag is deprecated and will be removed.",
+        "Please specify the instance as URL instead.",
+        "e.g. instead of writing:",
+        "  toot instance unsafehost.com --disable-https",
+        "instead write:",
+        "  toot instance http://unsafehost.com\n"
+    ]))


### PR DESCRIPTION
The instance domain can be different from their base url, for example the instance at https://social.vivaldi.net/ uses the vivaldi.net domain, sans 'social'.

This commit requires the user to provide the base url of the instance, instead of domain name. The domain is then fetched from the server.