### PR TITLE
Fix [b]oost so it works on statuses that were also boosted by others

### DIFF
--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -595,17 +595,17 @@ class TUI(urwid.Frame):
     def async_toggle_reblog(self, timeline, status):
         def _reblog():
             logger.info("Reblogging {}".format(status))
-            api.reblog(self.app, self.user, status.id, visibility=get_default_visibility())
+            api.reblog(self.app, self.user, status.original.id, visibility=get_default_visibility())
 
         def _unreblog():
             logger.info("Unreblogging {}".format(status))
-            api.unreblog(self.app, self.user, status.id)
+            api.unreblog(self.app, self.user, status.original.id)
 
         def _done(loop):
             # Create a new Status with flipped reblogged flag
             new_data = status.data
-            new_data["reblogged"] = not status.reblogged
             new_status = self.make_status(new_data)
+            new_status.original.reblogged = not status.original.reblogged
             timeline.update_status(new_status)
 
         # Check if status is rebloggable
@@ -616,7 +616,7 @@ class TUI(urwid.Frame):
             return
 
         self.run_in_thread(
-            _unreblog if status.reblogged else _reblog,
+            _unreblog if status.original.reblogged else _reblog,
             done_callback=_done
         )
 

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -493,7 +493,8 @@ class TUI(urwid.Frame):
     def goto_public_timeline(self, local):
         self.timeline_generator = api.public_timeline_generator(
             self.app, self.user, local=local, limit=40)
-        promise = self.async_load_timeline(is_initial=True, timeline_name="local public" if local else "global public")
+        timeline_name = "local public" if local else "global public"
+        promise = self.async_load_timeline(is_initial=True, timeline_name=timeline_name)
         promise.add_done_callback(lambda *args: self.close_overlay())
 
     def goto_bookmarks(self):
@@ -715,6 +716,31 @@ class TUI(urwid.Frame):
         if self.timeline:
             self.timeline.refresh_status_details()
 
+    def refresh_timeline(self):
+        # No point in refreshing the bookmarks timeline
+        if not self.timeline or self.timeline.name == 'bookmarks':
+            return
+
+        if self.timeline.name.startswith("#"):
+            self.timeline_generator = api.tag_timeline_generator(
+                self.app, self.user, self.timeline.name[1:], limit=40)
+        else:
+            if self.timeline.name.endswith("public"):
+                self.timeline_generator = api.public_timeline_generator(
+                    self.app, self.user, local=self.timeline.name.startswith("local"), limit=40)
+            elif self.timeline.name == "notifications":
+                self.timeline_generator = api.notification_timeline_generator(
+                    self.app, self.user, limit=40)
+            elif self.timeline.name == "conversations":
+                self.timeline_generator = api.conversation_timeline_generator(
+                    self.app, self.user, limit=40)
+            else:
+                # default to home timeline
+                self.timeline_generator = api.home_timeline_generator(
+                    self.app, self.user, limit=40)
+
+        self.async_load_timeline(is_initial=True, timeline_name=self.timeline.name)
+
     # --- Keys -----------------------------------------------------------------
 
     def unhandled_input(self, key):
@@ -733,27 +759,7 @@ class TUI(urwid.Frame):
 
         elif key == ',':
             if not self.overlay:
-                if self.timeline.name == 'bookmarks':
-                    return  # no point in refreshing the bookmarks timeline
-                if self.timeline.name.startswith("#"):
-                    self.timeline_generator = api.tag_timeline_generator(
-                        self.app, self.user, self.timeline.name[1:], limit=40)
-                else:
-                    if self.timeline.name.endswith('public'):
-                        self.timeline_generator = api.public_timeline_generator(
-                            self.app, self.user, local=self.timeline.name.startswith('local'), limit=40)
-                    elif self.timeline.name == 'notifications':
-                        self.timeline_generator = api.notification_timeline_generator(
-                            self.app, self.user, limit=40)
-                    elif self.timeline.name == 'conversations':
-                        self.timeline_generator = api.conversation_timeline_generator(
-                            self.app, self.user, limit=40)
-                    else:
-                        # default to home timeline
-                        self.timeline_generator = api.home_timeline_generator(
-                            self.app, self.user, limit=40)
-
-                self.async_load_timeline(is_initial=True, timeline_name=self.timeline.name)
+                self.refresh_timeline()
 
         elif key == 'esc':
             if self.overlay:


### PR DESCRIPTION
Boosting of statuses that others have already boosted, doesn't work properly in the TUI (try it and watch the yellow boost flag; it doesn't toggle on/off as you would expect).

These changes properly refer to the original status when boosting / unboosting, and when creating the new status for display. You can verify that toggling works correctly.  Boosting of non-boosted statuses also continues to work correctly.