### PR TITLE
Login to servers that don't honor the uri spec for V1::Instance

### DIFF
--- a/toot/auth.py
+++ b/toot/auth.py
@@ -7,6 +7,7 @@ from getpass import getpass
 from toot import api, config, DEFAULT_INSTANCE, User, App
 from toot.exceptions import ApiError, ConsoleError
 from toot.output import print_out
+from urllib.parse import urlparse
 
 
 def register_app(domain, base_url):
@@ -46,8 +47,20 @@ def get_instance_domain(base_url):
         f"running Mastodon version <yellow>{instance['version']}</yellow>"
     )
 
+    # Pleroma and its forks return an actual URI here, rather than a
+    # domain name like Mastodon. This is contrary to the spec.¯
+    # in that case, parse out the domain and return it.
+
+    parsed_uri = urlparse(instance["uri"])
+
+    if parsed_uri.netloc:
+        # Pleroma, Akkoma, GotoSocial, etc.
+        return parsed_uri.netloc
+    else:
+        # Others including Mastodon servers
+        return parsed_uri.path
+
     # NB: when updating to v2 instance endpoint, this field has been renamed to `domain`
-    return instance["uri"]
 
 
 def create_user(app, access_token):


### PR DESCRIPTION
Pleroma, Akkoma, and other servers do not follow the Mastodon spec for the 'uri' attribute which specifies that it contains the domain name of the instance. Instead, they return a complete URI.

As a workaround, we now detect this situation and parse out the domain from the URI when necessary. Fixes #347 

Thanks to @laleanor for their patch and @rjp for ideas on how to make it work with GotoSocial and other servers