### PR TITLE
If toot activate is invoked without an account, show list of accounts

### DIFF
--- a/toot/commands.py
+++ b/toot/commands.py
@@ -9,7 +9,7 @@ from toot.auth import login_interactive, login_browser_interactive, create_app_i
 from toot.exceptions import ApiError, ConsoleError
 from toot.output import (print_lists, print_out, print_instance, print_account, print_acct_list,
                          print_search_results, print_timeline, print_notifications, print_tag_list,
-                         print_list_accounts)
+                         print_list_accounts, print_user_list)
 from toot.tui.utils import parse_datetime
 from toot.utils import args_get_instance, delete_tmp_status_file, editor_input, multiline_input, EOF_KEY
 
@@ -334,6 +334,12 @@ def logout(app, user, args):
 
 
 def activate(app, user, args):
+    if not args.account:
+        print_out("<green>Specify one of the following user accounts to activate:</green>\n")
+        print_user_list(config.get_user_list())
+        print_out("\n")
+        return
+
     user = config.load_user(args.account, throw=True)
     config.activate_user(user)
     print_out("<green>✓ User {} active</green>".format(config.user_id(user)))

--- a/toot/config.py
+++ b/toot/config.py
@@ -120,6 +120,11 @@ def load_user(user_id, throw=False):
         raise ConsoleError("User '{}' not found".format(user_id))
 
 
+def get_user_list():
+    config = load_config()
+    return config['users']
+
+
 def modify_config(f):
     @wraps(f)
     def wrapper(*args, **kwargs):

--- a/toot/console.py
+++ b/toot/console.py
@@ -190,6 +190,10 @@ common_auth_args = [
 account_arg = (["account"], {
     "help": "account name, e.g. 'Gargron@mastodon.social'",
 })
+optional_account_arg = (["account"], {
+    "nargs": "?",
+    "help": "account name, e.g. 'Gargron@mastodon.social'",
+})
 
 instance_arg = (["-i", "--instance"], {
     "type": str,
@@ -289,7 +293,7 @@ AUTH_COMMANDS = [
     Command(
         name="activate",
         description="Switch between logged in accounts.",
-        arguments=[account_arg],
+        arguments=[optional_account_arg],
         require_auth=False,
     ),
     Command(

--- a/toot/output.py
+++ b/toot/output.py
@@ -203,6 +203,11 @@ def print_acct_list(accounts):
         print_out(f"* <green>@{account['acct']}</green> {account['display_name']}")
 
 
+def print_user_list(users):
+    for user in users:
+        print_out(f"<green>{user}</green>")
+
+
 def print_tag_list(tags):
     if tags:
         for tag in tags:


### PR DESCRIPTION
```
❯ toot activate
Specify one of the following user accounts to activate:

ds212@babka.social
ds212@blob.cat
ds212@newsie.social
ds212@vivaldi.net
dschwarz@toad.social


~/de/toot activate_user_list *23 ?15 ❯     
```