### PR TITLE
Fixes issue #353 by using urwid_readline library in EditBox widget

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests>=2.13,<3.0
 beautifulsoup4>=4.5.0,<5.0
 wcwidth>=0.1.7
 urwid>=2.0.0,<3.0
-
+urwid_readline>=0.13

--- a/toot/tui/widgets.py
+++ b/toot/tui/widgets.py
@@ -1,4 +1,5 @@
 import urwid
+import urwid_readline
 from wcwidth import wcswidth
 
 
@@ -33,7 +34,7 @@ class SelectableColumns(Clickable, urwid.Columns):
 class EditBox(urwid.AttrWrap):
     """Styled edit box."""
     def __init__(self, *args, **kwargs):
-        self.edit = urwid.Edit(*args, **kwargs)
+        self.edit = urwid_readline.ReadlineEdit(*args, **kwargs)
         return super().__init__(self.edit, "editbox", "editbox_focused")
 
 


### PR DESCRIPTION
This provides readline-style cursor controls, cut/paste, etc.
Adds a new dependency on [urwid_readline](https://pypi.org/project/urwid-readline/), a straightforward set of enhancements to `urwid.Edit` 