### PR TITLE
Add "muted" & "blocked" commands

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -521,6 +521,10 @@ def unmute(app, user, account):
     return _account_action(app, user, account, 'unmute')
 
 
+def muted(app, user):
+    return _get_response_list(app, user, "/api/v1/mutes")
+
+
 def block(app, user, account):
     return _account_action(app, user, account, 'block')
 

--- a/toot/api.py
+++ b/toot/api.py
@@ -533,6 +533,10 @@ def unblock(app, user, account):
     return _account_action(app, user, account, 'unblock')
 
 
+def blocked(app, user):
+    return _get_response_list(app, user, "/api/v1/blocks")
+
+
 def verify_credentials(app, user):
     return http.get(app, user, '/api/v1/accounts/verify_credentials').json()
 

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -493,6 +493,11 @@ def unmute(app, user, args):
     print_out("<green>✓ {} is no longer muted</green>".format(args.account))
 
 
+def muted(app, user, args):
+    response = api.muted(app, user)
+    print_acct_list(response)
+
+
 def block(app, user, args):
     account = api.find_account(app, user, args.account)
     api.block(app, user, account['id'])

--- a/toot/commands.py
+++ b/toot/commands.py
@@ -510,6 +510,11 @@ def unblock(app, user, args):
     print_out("<green>✓ {} is no longer blocked</green>".format(args.account))
 
 
+def blocked(app, user, args):
+    response = api.blocked(app, user)
+    print_acct_list(response)
+
+
 def whoami(app, user, args):
     account = api.verify_credentials(app, user)
     print_account(account)

--- a/toot/console.py
+++ b/toot/console.py
@@ -726,6 +726,12 @@ ACCOUNTS_COMMANDS = [
         ],
         require_auth=True,
     ),
+    Command(
+        name="blocked",
+        description="List accounts the given account muted",
+        arguments=[],
+        require_auth=True,
+    ),
 ]
 
 TAG_COMMANDS = [

--- a/toot/console.py
+++ b/toot/console.py
@@ -705,6 +705,12 @@ ACCOUNTS_COMMANDS = [
         require_auth=True,
     ),
     Command(
+        name="muted",
+        description="List accounts the given account muted",
+        arguments=[],
+        require_auth=True,
+    ),
+    Command(
         name="block",
         description="Block an account",
         arguments=[


### PR DESCRIPTION
I'd like to regularly backup my following, blocked and muted lists.

I can already use the "following" command to get a list of accounts I follow,
this adds two more commands for blocked and muted.

Both commands are very similar so I put them into the same pull request.
I'm happy to split this into two PRs.
