### PR TITLE
Proof of concept for issue #416 - adds Markdown rendering in TUI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "beautifulsoup4>=4.5.0,<5.0",
         "wcwidth>=0.1.7",
         "urwid>=2.0.0,<3.0",
-        "tomlkit>=0.10.0,<1.0"
+        "tomlkit>=0.10.0,<1.0",
         "html2text>=2020.1.16"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "wcwidth>=0.1.7",
         "urwid>=2.0.0,<3.0",
         "tomlkit>=0.10.0,<1.0"
+        "html2text>=2020.1.16"
     ],
     extras_require={
         # Required to display rich text in the TUI

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -153,6 +153,210 @@ def test_timeline(mock_get, monkeypatch, capsys):
 
 
 @mock.patch('toot.http.get')
+def test_timeline_html_content(mock_get, monkeypatch, capsys):
+    mock_get.return_value = MockResponse([{
+        'id': '111111111111111111',
+        'account': {
+            'display_name': 'Frank Zappa 🎸',
+            'acct': 'fz'
+        },
+        'created_at': '2017-04-12T15:53:18.174Z',
+        'content': "<h2>HTML Render Test</h2><p><em>emphasized</em><br><u>underlined</u><br><strong>bold</strong><br><strong><em>bold and italic</em></strong><br><del>strikethrough</del><br>regular text</p><p>Code block:</p><pre><code>10 PRINT \"HELLO WORLD\"<br>20 GOTO 10<br></code></pre><blockquote><p>Something blockquoted here. The indentation is maintained as the text line wraps.</p></blockquote><ol><li>List item<ul><li>Nested item</li><li>Another nested </li></ul></li><li>Another list item. <ol><li>Something else nested</li><li>And a last nested</li></ol></li></ol><blockquote><p>Blockquote</p><ol><li>List in BQ</li><li>List item 2 in BQ</li></ol></blockquote><p><a href=\"https://babka.social/tags/hashtag\" class=\"mention hashtag\" rel=\"tag\">#<span>hashtag</span></a> <a href=\"https://babka.social/tags/test\" class=\"mention hashtag\" rel=\"tag\">#<span>test</span></a> <br><a href=\"https://a.com\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"\">a.com</span><span class=\"invisible\"></span></a> text after link</p>",
+        'reblog': None,
+        'in_reply_to_id': None,
+        'media_attachments': [],
+    }])
+
+    console.run_command(app, user, 'timeline', ['--once'])
+
+    mock_get.assert_called_once_with(app, user, '/api/v1/timelines/home', {'limit': 10})
+
+    out, err = capsys.readouterr()
+    lines = out.split("\n")  
+    reference = [
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "Frank Zappa 🎸 @fz                                                              2017-04-12 15:53 UTC",
+        "",
+        "## HTML Render Test",
+        "",
+        " _emphasized_  ",
+        " _underlined_  ",
+        " **bold**  ",
+        " ** _bold and italic_**  ",
+        " ~~strikethrough~~  ",
+        "regular text",
+        "",
+        "Code block:",
+        "",
+        "    ",
+        "    10 PRINT \"HELLO WORLD\"  ",
+        "    20 GOTO 10  ",
+        "    ",
+        "> Something blockquoted here. The indentation is maintained as the text line wraps.",
+        "  1. List item",
+        "    • Nested item",
+        "    • Another nested ",
+        "  2. Another list item. ",
+        "    1. Something else nested",
+        "    2. And a last nested",
+        "",
+        "> Blockquote",
+        ">   1. List in BQ",
+        ">   2. List item 2 in BQ",
+        ">",
+        "",
+        "#hashtag #test  ",
+        "https://a.com text after link",
+        "",
+        "ID 111111111111111111   ",
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "",
+    ]
+
+    assert len(lines) == len(reference)
+    for index, line in enumerate(lines):
+        assert line == reference[index], f"Line #{index}: Expected:\n{reference[index]}\nGot:\n{line}"
+
+    assert err == ""
+
+
+@mock.patch('toot.http.get')
+def test_timeline_html_content(mock_get, monkeypatch, capsys):
+    mock_get.return_value = MockResponse([{
+        'id': '111111111111111111',
+        'account': {
+            'display_name': 'Frank Zappa 🎸',
+            'acct': 'fz'
+        },
+        'created_at': '2017-04-12T15:53:18.174Z',
+        'content': "<h2>HTML Render Test</h2><p><em>emphasized</em><br><u>underlined</u><br><strong>bold</strong><br><strong><em>bold and italic</em></strong><br><del>strikethrough</del><br>regular text</p><p>Code block:</p><pre><code>10 PRINT \"HELLO WORLD\"<br>20 GOTO 10<br></code></pre><blockquote><p>Something blockquoted here. The indentation is maintained as the text line wraps.</p></blockquote><ol><li>List item<ul><li>Nested item</li><li>Another nested </li></ul></li><li>Another list item. <ol><li>Something else nested</li><li>And a last nested</li></ol></li></ol><blockquote><p>Blockquote</p><ol><li>List in BQ</li><li>List item 2 in BQ</li></ol></blockquote><p><a href=\"https://babka.social/tags/hashtag\" class=\"mention hashtag\" rel=\"tag\">#<span>hashtag</span></a> <a href=\"https://babka.social/tags/test\" class=\"mention hashtag\" rel=\"tag\">#<span>test</span></a> <br><a href=\"https://a.com\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"\">a.com</span><span class=\"invisible\"></span></a> text after link</p>",
+        'reblog': None,
+        'in_reply_to_id': None,
+        'media_attachments': [],
+    }])
+
+    console.run_command(app, user, 'timeline', ['--once'])
+
+    mock_get.assert_called_once_with(app, user, '/api/v1/timelines/home', {'limit': 10})
+
+    out, err = capsys.readouterr()
+    lines = out.split("\n")  
+    reference = [
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "Frank Zappa 🎸 @fz                                                              2017-04-12 15:53 UTC",
+        "",
+        "## HTML Render Test",
+        "",
+        " _emphasized_  ",
+        " _underlined_  ",
+        " **bold**  ",
+        " ** _bold and italic_**  ",
+        " ~~strikethrough~~  ",
+        "regular text",
+        "",
+        "Code block:",
+        "",
+        "    ",
+        "    10 PRINT \"HELLO WORLD\"  ",
+        "    20 GOTO 10  ",
+        "    ",
+        "> Something blockquoted here. The indentation is maintained as the text line wraps.",
+        "  1. List item",
+        "    • Nested item",
+        "    • Another nested ",
+        "  2. Another list item. ",
+        "    1. Something else nested",
+        "    2. And a last nested",
+        "",
+        "> Blockquote",
+        ">   1. List in BQ",
+        ">   2. List item 2 in BQ",
+        ">",
+        "",
+        "#hashtag #test  ",
+        "https://a.com text after link",
+        "",
+        "ID 111111111111111111   ",
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "",
+    ]
+
+    assert len(lines) == len(reference)
+    for index, line in enumerate(lines):
+        assert line == reference[index], f"Line #{index}: Expected:\n{reference[index]}\nGot:\n{line}"
+
+    assert err == ""
+
+
+@mock.patch('toot.http.get')
+def test_timeline_html_content(mock_get, monkeypatch, capsys):
+    mock_get.return_value = MockResponse([{
+        'id': '111111111111111111',
+        'account': {
+            'display_name': 'Frank Zappa 🎸',
+            'acct': 'fz'
+        },
+        'created_at': '2017-04-12T15:53:18.174Z',
+        'content': "<h2>HTML Render Test</h2><p><em>emphasized</em><br><u>underlined</u><br><strong>bold</strong><br><strong><em>bold and italic</em></strong><br><del>strikethrough</del><br>regular text</p><p>Code block:</p><pre><code>10 PRINT \"HELLO WORLD\"<br>20 GOTO 10<br></code></pre><blockquote><p>Something blockquoted here. The indentation is maintained as the text line wraps.</p></blockquote><ol><li>List item<ul><li>Nested item</li><li>Another nested </li></ul></li><li>Another list item. <ol><li>Something else nested</li><li>And a last nested</li></ol></li></ol><blockquote><p>Blockquote</p><ol><li>List in BQ</li><li>List item 2 in BQ</li></ol></blockquote><p><a href=\"https://babka.social/tags/hashtag\" class=\"mention hashtag\" rel=\"tag\">#<span>hashtag</span></a> <a href=\"https://babka.social/tags/test\" class=\"mention hashtag\" rel=\"tag\">#<span>test</span></a> <br><a href=\"https://a.com\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"\">a.com</span><span class=\"invisible\"></span></a> text after link</p>",
+        'reblog': None,
+        'in_reply_to_id': None,
+        'media_attachments': [],
+    }])
+
+    console.run_command(app, user, 'timeline', ['--once'])
+
+    mock_get.assert_called_once_with(app, user, '/api/v1/timelines/home', {'limit': 10})
+
+    out, err = capsys.readouterr()
+    lines = out.split("\n")
+    reference = [
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "Frank Zappa 🎸 @fz                                                              2017-04-12 15:53 UTC",
+        "",
+        "## HTML Render Test",
+        "",
+        " _emphasized_  ",
+        " _underlined_  ",
+        " **bold**  ",
+        " ** _bold and italic_**  ",
+        " ~~strikethrough~~  ",
+        "regular text",
+        "",
+        "Code block:",
+        "",
+        "    ",
+        "    10 PRINT \"HELLO WORLD\"  ",
+        "    20 GOTO 10  ",
+        "    ",
+        "> Something blockquoted here. The indentation is maintained as the text line wraps.",
+        "  1. List item",
+        "    • Nested item",
+        "    • Another nested ",
+        "  2. Another list item. ",
+        "    1. Something else nested",
+        "    2. And a last nested",
+        "",
+        "> Blockquote",
+        ">   1. List in BQ",
+        ">   2. List item 2 in BQ",
+        ">",
+        "",
+        "#hashtag #test  ",
+        "https://a.com text after link",
+        "",
+        "ID 111111111111111111   ",
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "",
+    ]
+
+    assert len(lines) == len(reference)
+    for index, line in enumerate(lines):
+        assert line == reference[index], f"Line #{index}: Expected:\n{reference[index]}\nGot:\n{line}"
+
+    assert err == ""
+
+
+@mock.patch('toot.http.get')
 def test_timeline_with_re(mock_get, monkeypatch, capsys):
     mock_get.return_value = MockResponse([{
         'id': '111111111111111111',
@@ -588,8 +792,6 @@ def test_notifications(mock_get, capsys):
         "────────────────────────────────────────────────────────────────────────────────────────────────────",
         "",
     ])
-
-
 @mock.patch('toot.http.get')
 def test_notifications_empty(mock_get, capsys):
     mock_get.return_value = MockResponse([])

--- a/toot/output.py
+++ b/toot/output.py
@@ -2,10 +2,11 @@ import os
 import re
 import sys
 import textwrap
+import html2text
 
 from functools import lru_cache
 from toot import settings
-from toot.utils import get_text, html_to_paragraphs
+from toot.utils import get_text
 from toot.entities import Account, Instance, Notification, Poll, Status
 from toot.wcstring import wc_wrap
 from typing import List
@@ -174,7 +175,6 @@ def print_account(account: Account):
     print_out(f"<green>@{account.acct}</green> {account.display_name}")
 
     if account.note:
-        print_out("")
         print_html(account.note)
 
     since = account.created_at.strftime('%Y-%m-%d')
@@ -299,7 +299,6 @@ def print_status(status: Status, width: int = 80):
         f"<yellow>{time}</yellow>",
     )
 
-    print_out("")
     print_html(status.content, width)
 
     if status.media_attachments:
@@ -322,14 +321,20 @@ def print_status(status: Status, width: int = 80):
 
 
 def print_html(text, width=80):
-    first = True
-    for paragraph in html_to_paragraphs(text):
-        if not first:
-            print_out("")
-        for line in paragraph:
-            for subline in wc_wrap(line, width):
-                print_out(highlight_hashtags(subline))
-        first = False
+    h2t = html2text.HTML2Text()
+
+    h2t.body_width = width
+    h2t.single_line_break = True
+    h2t.ignore_links = True
+    h2t.wrap_links = True
+    h2t.wrap_list_items = True
+    h2t.wrap_tables = True
+    h2t.unicode_snob = True
+    h2t.ul_item_mark = "\N{bullet}"
+    markdown = h2t.handle(text).strip()
+
+    print_out("")
+    print_out(highlight_hashtags(markdown))
 
 
 def print_poll(poll: Poll):

--- a/toot/tui/richtext/__init__.py
+++ b/toot/tui/richtext/__init__.py
@@ -1,7 +1,6 @@
 import urwid
 import html2text
 
-from toot.tui.utils import highlight_hashtags
 from typing import List
 
 try:
@@ -10,7 +9,7 @@ except ImportError:
     # Fallback if urwidgets are not available
     def html_to_widgets(html: str) -> List[urwid.Widget]:
         return [
-            urwid.Text(highlight_hashtags(_format_markdown(html)))
+            urwid.Text(_format_markdown(html))
         ]
 
     def url_to_widget(url: str):

--- a/toot/tui/richtext/__init__.py
+++ b/toot/tui/richtext/__init__.py
@@ -1,7 +1,7 @@
 import urwid
+import html2text
 
 from toot.tui.utils import highlight_hashtags
-from toot.utils import format_content
 from typing import List
 
 try:
@@ -10,9 +10,19 @@ except ImportError:
     # Fallback if urwidgets are not available
     def html_to_widgets(html: str) -> List[urwid.Widget]:
         return [
-            urwid.Text(highlight_hashtags(line))
-            for line in format_content(html)
+            urwid.Text(highlight_hashtags(_format_markdown(html)))
         ]
 
     def url_to_widget(url: str):
         return urwid.Text(("link", url))
+
+    def _format_markdown(html) -> str:
+        h2t = html2text.HTML2Text()
+        h2t.single_line_break = True
+        h2t.ignore_links = True
+        h2t.wrap_links = False
+        h2t.wrap_list_items = False
+        h2t.wrap_tables = False
+        h2t.unicode_snob = True
+        h2t.ul_item_mark = "\N{bullet}"
+        return h2t.handle(html).strip()


### PR DESCRIPTION
Here's a PR against master that uses [html2text](https://pypi.org/project/html2text/) to render statuses in Markdown. (per issue #416)  It does this all the time for console output (`toot timeline` etc.) and copy-to-clipboard.  In the TUI, it renders Markdown as a fallback if the `urwidgets` library is unavailable.

It works OK, but has some rendering challenges due to quirks and limitations of html2text.  I think I'll try substituting ~~[markdown-it-py](https://github.com/executablebooks/markdown-it-py) to see if it does a better job.~~  Turns out, markdown-it-py goes the _opposite direction_, from markdown to HTML.

I tested [markdownify](https://github.com/matthewwithanm/python-markdownify) instead; it's less flexible than html2text and has its own quirks, so it's a question of which library's quirks we can put up with.  Or find another.  The only other solution I've found is [pandoc](https://pypi.org/project/pandoc/),  which relies on a Haskell library. So that's not ideal.

For the moment, I'm sticking with html2text.

![image](https://github.com/ihabunek/toot/assets/3261094/ec9307b8-deaa-4ef8-9805-9089518b8534)


Another issue is that urwid Text widgets wrap text as needed, and html2text depends on fixed width lines in order to render things like blockquotes and lists correctly.  If the TUI status window is too narrow, blockquotes and lists won't look right.  Not much we can do about this other than detect the status window width and re-render the Markdown on any window resize 🤮 .  Or ignore the problem (my preferred solution.)   You can see an example of this line wrapping problem in the image below:
![image](https://github.com/ihabunek/toot/assets/3261094/46a7952f-a874-4ca9-9ef2-0200baf2d077)

