### PR TITLE
Add support for markdown in TUI, console, clipboard using pypandoc library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
         "wcwidth>=0.1.7",
         "urwid>=2.0.0,<3.0",
         "tomlkit>=0.10.0,<1.0",
-        "html2text>=2020.1.16"
+        "pypandoc>=1.12.0,<2.0",
+        "pypandoc-binary>=1.12.0,<2.0"
     ],
     extras_require={
         # Required to display rich text in the TUI

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "beautifulsoup4>=4.5.0,<5.0",
         "wcwidth>=0.1.7",
         "urwid>=2.0.0,<3.0",
-        "tomlkit>=0.10.0,<1.0"
+        "tomlkit>=0.10.0,<1.0",
         "html2text>=2020.1.16"
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "wcwidth>=0.1.7",
         "urwid>=2.0.0,<3.0",
         "tomlkit>=0.10.0,<1.0"
+        "html2text>=2020.1.16"
     ],
     extras_require={
         # Required to display rich text in the TUI

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -153,6 +153,210 @@ def test_timeline(mock_get, monkeypatch, capsys):
 
 
 @mock.patch('toot.http.get')
+def test_timeline_html_content(mock_get, monkeypatch, capsys):
+    mock_get.return_value = MockResponse([{
+        'id': '111111111111111111',
+        'account': {
+            'display_name': 'Frank Zappa 🎸',
+            'acct': 'fz'
+        },
+        'created_at': '2017-04-12T15:53:18.174Z',
+        'content': "<h2>HTML Render Test</h2><p><em>emphasized</em><br><u>underlined</u><br><strong>bold</strong><br><strong><em>bold and italic</em></strong><br><del>strikethrough</del><br>regular text</p><p>Code block:</p><pre><code>10 PRINT \"HELLO WORLD\"<br>20 GOTO 10<br></code></pre><blockquote><p>Something blockquoted here. The indentation is maintained as the text line wraps.</p></blockquote><ol><li>List item<ul><li>Nested item</li><li>Another nested </li></ul></li><li>Another list item. <ol><li>Something else nested</li><li>And a last nested</li></ol></li></ol><blockquote><p>Blockquote</p><ol><li>List in BQ</li><li>List item 2 in BQ</li></ol></blockquote><p><a href=\"https://babka.social/tags/hashtag\" class=\"mention hashtag\" rel=\"tag\">#<span>hashtag</span></a> <a href=\"https://babka.social/tags/test\" class=\"mention hashtag\" rel=\"tag\">#<span>test</span></a> <br><a href=\"https://a.com\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"\">a.com</span><span class=\"invisible\"></span></a> text after link</p>",
+        'reblog': None,
+        'in_reply_to_id': None,
+        'media_attachments': [],
+    }])
+
+    console.run_command(app, user, 'timeline', ['--once'])
+
+    mock_get.assert_called_once_with(app, user, '/api/v1/timelines/home', {'limit': 10})
+
+    out, err = capsys.readouterr()
+    lines = out.split("\n")  
+    reference = [
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "Frank Zappa 🎸 @fz                                                              2017-04-12 15:53 UTC",
+        "",
+        "## HTML Render Test",
+        "",
+        " _emphasized_  ",
+        " _underlined_  ",
+        " **bold**  ",
+        " ** _bold and italic_**  ",
+        " ~~strikethrough~~  ",
+        "regular text",
+        "",
+        "Code block:",
+        "",
+        "    ",
+        "    10 PRINT \"HELLO WORLD\"  ",
+        "    20 GOTO 10  ",
+        "    ",
+        "> Something blockquoted here. The indentation is maintained as the text line wraps.",
+        "  1. List item",
+        "    • Nested item",
+        "    • Another nested ",
+        "  2. Another list item. ",
+        "    1. Something else nested",
+        "    2. And a last nested",
+        "",
+        "> Blockquote",
+        ">   1. List in BQ",
+        ">   2. List item 2 in BQ",
+        ">",
+        "",
+        "#hashtag #test  ",
+        "https://a.com text after link",
+        "",
+        "ID 111111111111111111   ",
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "",
+    ]
+
+    assert len(lines) == len(reference)
+    for index, line in enumerate(lines):
+        assert line == reference[index], f"Line #{index}: Expected:\n{reference[index]}\nGot:\n{line}"
+
+    assert err == ""
+
+
+@mock.patch('toot.http.get')
+def test_timeline_html_content(mock_get, monkeypatch, capsys):
+    mock_get.return_value = MockResponse([{
+        'id': '111111111111111111',
+        'account': {
+            'display_name': 'Frank Zappa 🎸',
+            'acct': 'fz'
+        },
+        'created_at': '2017-04-12T15:53:18.174Z',
+        'content': "<h2>HTML Render Test</h2><p><em>emphasized</em><br><u>underlined</u><br><strong>bold</strong><br><strong><em>bold and italic</em></strong><br><del>strikethrough</del><br>regular text</p><p>Code block:</p><pre><code>10 PRINT \"HELLO WORLD\"<br>20 GOTO 10<br></code></pre><blockquote><p>Something blockquoted here. The indentation is maintained as the text line wraps.</p></blockquote><ol><li>List item<ul><li>Nested item</li><li>Another nested </li></ul></li><li>Another list item. <ol><li>Something else nested</li><li>And a last nested</li></ol></li></ol><blockquote><p>Blockquote</p><ol><li>List in BQ</li><li>List item 2 in BQ</li></ol></blockquote><p><a href=\"https://babka.social/tags/hashtag\" class=\"mention hashtag\" rel=\"tag\">#<span>hashtag</span></a> <a href=\"https://babka.social/tags/test\" class=\"mention hashtag\" rel=\"tag\">#<span>test</span></a> <br><a href=\"https://a.com\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"\">a.com</span><span class=\"invisible\"></span></a> text after link</p>",
+        'reblog': None,
+        'in_reply_to_id': None,
+        'media_attachments': [],
+    }])
+
+    console.run_command(app, user, 'timeline', ['--once'])
+
+    mock_get.assert_called_once_with(app, user, '/api/v1/timelines/home', {'limit': 10})
+
+    out, err = capsys.readouterr()
+    lines = out.split("\n")  
+    reference = [
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "Frank Zappa 🎸 @fz                                                              2017-04-12 15:53 UTC",
+        "",
+        "## HTML Render Test",
+        "",
+        " _emphasized_  ",
+        " _underlined_  ",
+        " **bold**  ",
+        " ** _bold and italic_**  ",
+        " ~~strikethrough~~  ",
+        "regular text",
+        "",
+        "Code block:",
+        "",
+        "    ",
+        "    10 PRINT \"HELLO WORLD\"  ",
+        "    20 GOTO 10  ",
+        "    ",
+        "> Something blockquoted here. The indentation is maintained as the text line wraps.",
+        "  1. List item",
+        "    • Nested item",
+        "    • Another nested ",
+        "  2. Another list item. ",
+        "    1. Something else nested",
+        "    2. And a last nested",
+        "",
+        "> Blockquote",
+        ">   1. List in BQ",
+        ">   2. List item 2 in BQ",
+        ">",
+        "",
+        "#hashtag #test  ",
+        "https://a.com text after link",
+        "",
+        "ID 111111111111111111   ",
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "",
+    ]
+
+    assert len(lines) == len(reference)
+    for index, line in enumerate(lines):
+        assert line == reference[index], f"Line #{index}: Expected:\n{reference[index]}\nGot:\n{line}"
+
+    assert err == ""
+
+
+@mock.patch('toot.http.get')
+def test_timeline_html_content(mock_get, monkeypatch, capsys):
+    mock_get.return_value = MockResponse([{
+        'id': '111111111111111111',
+        'account': {
+            'display_name': 'Frank Zappa 🎸',
+            'acct': 'fz'
+        },
+        'created_at': '2017-04-12T15:53:18.174Z',
+        'content': "<h2>HTML Render Test</h2><p><em>emphasized</em><br><u>underlined</u><br><strong>bold</strong><br><strong><em>bold and italic</em></strong><br><del>strikethrough</del><br>regular text</p><p>Code block:</p><pre><code>10 PRINT \"HELLO WORLD\"<br>20 GOTO 10<br></code></pre><blockquote><p>Something blockquoted here. The indentation is maintained as the text line wraps.</p></blockquote><ol><li>List item<ul><li>Nested item</li><li>Another nested </li></ul></li><li>Another list item. <ol><li>Something else nested</li><li>And a last nested</li></ol></li></ol><blockquote><p>Blockquote</p><ol><li>List in BQ</li><li>List item 2 in BQ</li></ol></blockquote><p><a href=\"https://babka.social/tags/hashtag\" class=\"mention hashtag\" rel=\"tag\">#<span>hashtag</span></a> <a href=\"https://babka.social/tags/test\" class=\"mention hashtag\" rel=\"tag\">#<span>test</span></a> <br><a href=\"https://a.com\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"\">a.com</span><span class=\"invisible\"></span></a> text after link</p>",
+        'reblog': None,
+        'in_reply_to_id': None,
+        'media_attachments': [],
+    }])
+
+    console.run_command(app, user, 'timeline', ['--once'])
+
+    mock_get.assert_called_once_with(app, user, '/api/v1/timelines/home', {'limit': 10})
+
+    out, err = capsys.readouterr()
+    lines = out.split("\n")
+    reference = [
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "Frank Zappa 🎸 @fz                                                              2017-04-12 15:53 UTC",
+        "",
+        "## HTML Render Test",
+        "",
+        " _emphasized_  ",
+        " _underlined_  ",
+        " **bold**  ",
+        " ** _bold and italic_**  ",
+        " ~~strikethrough~~  ",
+        "regular text",
+        "",
+        "Code block:",
+        "",
+        "    ",
+        "    10 PRINT \"HELLO WORLD\"  ",
+        "    20 GOTO 10  ",
+        "    ",
+        "> Something blockquoted here. The indentation is maintained as the text line wraps.",
+        "  1. List item",
+        "    • Nested item",
+        "    • Another nested ",
+        "  2. Another list item. ",
+        "    1. Something else nested",
+        "    2. And a last nested",
+        "",
+        "> Blockquote",
+        ">   1. List in BQ",
+        ">   2. List item 2 in BQ",
+        ">",
+        "",
+        "#hashtag #test  ",
+        "https://a.com text after link",
+        "",
+        "ID 111111111111111111   ",
+        "────────────────────────────────────────────────────────────────────────────────────────────────────",
+        "",
+    ]
+
+    assert len(lines) == len(reference)
+    for index, line in enumerate(lines):
+        assert line == reference[index], f"Line #{index}: Expected:\n{reference[index]}\nGot:\n{line}"
+
+    assert err == ""
+
+
+@mock.patch('toot.http.get')
 def test_timeline_with_re(mock_get, monkeypatch, capsys):
     mock_get.return_value = MockResponse([{
         'id': '111111111111111111',
@@ -588,8 +792,6 @@ def test_notifications(mock_get, capsys):
         "────────────────────────────────────────────────────────────────────────────────────────────────────",
         "",
     ])
-
-
 @mock.patch('toot.http.get')
 def test_notifications_empty(mock_get, capsys):
     mock_get.return_value = MockResponse([])

--- a/toot/output.py
+++ b/toot/output.py
@@ -2,10 +2,11 @@ import os
 import re
 import sys
 import textwrap
+import html2text
 
 from functools import lru_cache
 from toot import settings
-from toot.utils import get_text, html_to_paragraphs
+from toot.utils import get_text
 from toot.entities import Account, Instance, Notification, Poll, Status
 from toot.wcstring import wc_wrap
 from typing import List
@@ -174,7 +175,6 @@ def print_account(account: Account):
     print_out(f"<green>@{account.acct}</green> {account.display_name}")
 
     if account.note:
-        print_out("")
         print_html(account.note)
 
     since = account.created_at.strftime('%Y-%m-%d')
@@ -299,7 +299,6 @@ def print_status(status: Status, width: int = 80):
         f"<yellow>{time}</yellow>",
     )
 
-    print_out("")
     print_html(status.content, width)
 
     if status.media_attachments:
@@ -322,14 +321,20 @@ def print_status(status: Status, width: int = 80):
 
 
 def print_html(text, width=80):
-    first = True
-    for paragraph in html_to_paragraphs(text):
-        if not first:
-            print_out("")
-        for line in paragraph:
-            for subline in wc_wrap(line, width):
-                print_out(highlight_hashtags(subline))
-        first = False
+    h2t = html2text.HTML2Text()
+
+    h2t.body_width = width
+    h2t.single_line_break = True
+    h2t.ignore_links = True
+    h2t.wrap_links = True
+    h2t.wrap_list_items = True
+    h2t.wrap_tables = True
+    h2t.unicode_snob = True
+    h2t.ul_item_mark = "\N{bullet}"
+    markdown = h2t.handle(text).strip()
+
+    print_out("")
+    print_out(highlight_hashtags(markdown))
 
 
 def print_poll(poll: Poll):

--- a/toot/output.py
+++ b/toot/output.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 import textwrap
-import html2text
+import pypandoc
 
 from functools import lru_cache
 from toot import settings
@@ -321,17 +321,10 @@ def print_status(status: Status, width: int = 80):
 
 
 def print_html(text, width=80):
-    h2t = html2text.HTML2Text()
-
-    h2t.body_width = width
-    h2t.single_line_break = True
-    h2t.ignore_links = True
-    h2t.wrap_links = True
-    h2t.wrap_list_items = True
-    h2t.wrap_tables = True
-    h2t.unicode_snob = True
-    h2t.ul_item_mark = "\N{bullet}"
-    markdown = h2t.handle(text).strip()
+    markdown = pypandoc.convert_text(text,
+                                   format='html',
+                                     to='gfm-raw_html',
+                                     extra_args=["--wrap=auto", f"--columns={width}"])
 
     print_out("")
     print_out(highlight_hashtags(markdown))

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -1,7 +1,7 @@
 import logging
 import subprocess
 import urwid
-import html2text
+import pypandoc
 
 from concurrent.futures import ThreadPoolExecutor
 
@@ -656,12 +656,10 @@ class TUI(urwid.Frame):
         return self.run_in_thread(_delete, done_callback=_done)
 
     def copy_status(self, status):
-        h2t = html2text.HTML2Text()
-        h2t.body_width = 0  # nowrap
-        h2t.single_line_break = True
-        h2t.ignore_links = True
-        h2t.unicode_snob = True
-        h2t.ul_item_mark = "\N{bullet}"
+        markdown = pypandoc.convert_text(status.original.data["content"],
+                                         format='html',
+                                         to='gfm-raw_html',
+                                         extra_args=["--wrap=none"])
 
         time = parse_datetime(status.original.data['created_at'])
         time = time.strftime('%Y-%m-%d %H:%M %Z')
@@ -671,7 +669,7 @@ class TUI(urwid.Frame):
             + "\n"
             + (status.original.author.account or "")
             + "\n\n"
-            + h2t.handle(status.original.data["content"]).strip()
+            + markdown
             + "\n\n"
             + f"Created at: {time}")
 

--- a/toot/tui/richtext/__init__.py
+++ b/toot/tui/richtext/__init__.py
@@ -1,7 +1,6 @@
 import urwid
 import html2text
 
-from toot.tui.utils import highlight_hashtags
 from typing import List
 
 try:
@@ -10,7 +9,7 @@ except ImportError:
     # Fallback if urwidgets are not available
     def html_to_widgets(html: str) -> List[urwid.Widget]:
         return [
-            urwid.Text(highlight_hashtags(_format_markdown(html)))
+            urwid.Text(_format_markdown(html))
         ]
 
     def url_to_widget(url: str):

--- a/toot/tui/richtext/__init__.py
+++ b/toot/tui/richtext/__init__.py
@@ -1,27 +1,24 @@
 import urwid
-import html2text
-
+from toot.tui.utils import highlight_hashtags
+from toot.utils import format_content
 from typing import List
 
 try:
+    # our first preference is to render using urwidgets
     from .richtext import html_to_widgets, url_to_widget
+
 except ImportError:
-    # Fallback if urwidgets are not available
-    def html_to_widgets(html: str) -> List[urwid.Widget]:
-        return [
-            urwid.Text(_format_markdown(html))
-        ]
+    try:
+        # second preference, render markup with pypandoc
+        from .markdown import html_to_widgets, url_to_widget
 
-    def url_to_widget(url: str):
-        return urwid.Text(("link", url))
+    except ImportError:
+        # Fallback to render in plaintext
 
-    def _format_markdown(html) -> str:
-        h2t = html2text.HTML2Text()
-        h2t.single_line_break = True
-        h2t.ignore_links = True
-        h2t.wrap_links = False
-        h2t.wrap_list_items = False
-        h2t.wrap_tables = False
-        h2t.unicode_snob = True
-        h2t.ul_item_mark = "\N{bullet}"
-        return h2t.handle(html).strip()
+        def url_to_widget(url: str):
+            return urwid.Text(("link", url))
+
+        def html_to_widgets(html: str) -> List[urwid.Widget]:
+            return [
+                urwid.Text(highlight_hashtags(line)) for line in format_content(html)
+            ]

--- a/toot/tui/richtext/__init__.py
+++ b/toot/tui/richtext/__init__.py
@@ -1,7 +1,7 @@
 import urwid
+import html2text
 
 from toot.tui.utils import highlight_hashtags
-from toot.utils import format_content
 from typing import List
 
 try:
@@ -10,9 +10,19 @@ except ImportError:
     # Fallback if urwidgets are not available
     def html_to_widgets(html: str) -> List[urwid.Widget]:
         return [
-            urwid.Text(highlight_hashtags(line))
-            for line in format_content(html)
+            urwid.Text(highlight_hashtags(_format_markdown(html)))
         ]
 
     def url_to_widget(url: str):
         return urwid.Text(("link", url))
+
+    def _format_markdown(html) -> str:
+        h2t = html2text.HTML2Text()
+        h2t.single_line_break = True
+        h2t.ignore_links = True
+        h2t.wrap_links = False
+        h2t.wrap_list_items = False
+        h2t.wrap_tables = False
+        h2t.unicode_snob = True
+        h2t.ul_item_mark = "\N{bullet}"
+        return h2t.handle(html).strip()

--- a/toot/tui/richtext/markdown.py
+++ b/toot/tui/richtext/markdown.py
@@ -1,0 +1,19 @@
+import urwid
+from pypandoc import convert_text
+
+from typing import List
+
+def url_to_widget(url: str):
+    return urwid.Text(("link", url))
+
+def html_to_widgets(html: str) -> List[urwid.Widget]:
+    return [
+        urwid.Text(
+            convert_text(
+                html,
+                format="html",
+                to="gfm-raw_html",
+                extra_args=["--wrap=none"],
+            )
+        )
+    ]


### PR DESCRIPTION
As it turns out, the `pandoc` utility, with `pypandoc` Python bindings, do a better job converting HTML to markdown than `html2text` or `markdownify` libraries. `Pandoc` is widely used and maintained, in contrast to the other libraries.

In the TUI, statuses are rendered in HTML by `urwidgets` if available, fallback is markdown (via `pandoc` if available), and finally plaintext if neither `urwidgets` nor `pandoc` are available.

In the console and clipboard, status rendering is in markdown via `pandoc`, fallback to plaintext if `pandoc` is not available.

TODO:
1. Command line option or config file option to choose tui status rendering: HTML, markdown, or plaintext.
2. Command line option or config file option to choose console status rendering: markdown or plaintext.
3. Test cases to exercise all three rendering options correctly. At present, test_console.py (correctly) complains because statuses rendered as markdown do not match the expected plaintext rendering.

Here's an example of markdown rendering in the TUI.  This is using github-flavored-markdown, FWIW.

This addresses issue #416 .

![image](https://github.com/ihabunek/toot/assets/3261094/7fd5029d-6134-4b64-863f-a29ba132f9b7)

