### PR TITLE
added --color flag to force color even if stdout is a tty

### DIFF
--- a/toot/console.py
+++ b/toot/console.py
@@ -164,6 +164,11 @@ common_args = [
         "action": 'store_true',
         "default": False,
     }),
+    (["--color"], {
+        "help": "always use ANSI colors in output",
+        "action": 'store_true',
+        "default": False,
+    }),
     (["--quiet"], {
         "help": "don't write to stdout on success",
         "action": 'store_true',

--- a/toot/output.py
+++ b/toot/output.py
@@ -110,6 +110,11 @@ def use_ansi_color():
     if sys.platform == 'win32' and 'ANSICON' not in os.environ:
         return False
 
+    # With the --color flag, force color, even if stdout is a tty
+    # and even if --no-color is also specified (!)
+    if "--color" in sys.argv:
+        return True
+
     # Don't show color if stdout is not a tty, e.g. if output is piped on
     if not sys.stdout.isatty():
         return False


### PR DESCRIPTION
This option was inspired by @strk comment:
https://github.com/ihabunek/toot/issues/422#issuecomment-1842649257

Now there is a `--color` option that works exactly like (but opposite to) the `--no-color` option. 

There are other ways to implement this, possibly by replacing `--no-color` with something like `--color` with values like `yes`, `no`, `auto`  (auto being default and what the app currently does if no flag passed).

If you'd rather see the flag implemented that way, I can change the code.  Otherwise, this is good to go and allows things like

`toot timeline --count 20 --color | less -R`

to display timeline output, properly paged, in color.
