### PR TITLE
Add install-bash-completion and install-shell-completion targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,15 @@ bundle:
 		--output toot-`git describe`.pyz bundle \
 		--compress
 	echo "Bundle created: toot-`git describe`.pyz"
+
+
+# TODO: add more rules for more shells
+.PHONY: install-shell-completion
+install-shell-completion: install-bash-completion
+	@echo "See docs/shell_completion.md for Fish and Zsh completions"
+
+.PHONY: install-bash-completion
+install-bash-completion:
+	if test -d /etc/bash_completion.d; then \
+		cp scripts/bash_completion /etc/bash_completion.d/toot; \
+	fi

--- a/scripts/bash_completion
+++ b/scripts/bash_completion
@@ -1,0 +1,1 @@
+eval "$(_TOOT_COMPLETE=bash_source toot)"


### PR DESCRIPTION
I've only done bash as I use bash and have no idea how zsh and fish deal with custom completion files