### PR TITLE
Updated min version of urwid to 2.1.0 aligned with urwidgets library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "requests>=2.13,<3.0",
         "beautifulsoup4>=4.5.0,<5.0",
         "wcwidth>=0.1.7",
-        "urwid>=2.0.0,<3.0",
+        "urwid>=2.1.0,<3.0",
         "tomlkit>=0.10.0,<1.0"
     ],
     extras_require={


### PR DESCRIPTION
Urwidgets library requires urwid 2.1.0 so I've adjusted our minimum urwid version acordingly.

Note that urwidgets is an optional dependency, so if we really want to, we can leave our urwid version at 2.0.0.