### PR TITLE
add an option to automatically expand content warnings

### DIFF
--- a/toot/cli/tui.py
+++ b/toot/cli/tui.py
@@ -29,11 +29,17 @@ COLOR_OPTIONS = ", ".join(TUI_COLORS.keys())
     type=click.Choice(VISIBILITY_CHOICES),
     help="Default visibility when posting new toots; overrides the server-side preference"
 )
+@click.option(
+    "-S", "--always-show-sensitive",
+    is_flag=True,
+    help="Expand toots with content warnings automatically"
+)
 @pass_context
 def tui(
     ctx: Context,
     colors: Optional[int],
     media_viewer: Optional[str],
+    always_show_sensitive: bool,
     relative_datetimes: bool,
     default_visibility: Optional[str]
 ):
@@ -45,7 +51,8 @@ def tui(
         colors=colors,
         media_viewer=media_viewer,
         relative_datetimes=relative_datetimes,
-        default_visibility=default_visibility
+        default_visibility=default_visibility,
+        always_show_sensitive=always_show_sensitive,
     )
     tui = TUI.create(ctx.app, ctx.user, options)
     tui.run()

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -30,6 +30,7 @@ DEFAULT_MAX_TOOT_CHARS = 500
 class TuiOptions(NamedTuple):
     colors: int
     media_viewer: Optional[str]
+    always_show_sensitive: bool
     relative_datetimes: bool
     default_visibility: Optional[bool]
 

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -313,6 +313,7 @@ class StatusDetails(urwid.Pile):
     def __init__(self, timeline: Timeline, status: Optional[Status]):
         self.status = status
         self.followed_accounts = timeline.tui.followed_accounts
+        self.options = timeline.tui.options
 
         reblogged_by = status.author if status and status.reblog else None
         widget_list = list(self.content_generator(status.original, reblogged_by)
@@ -337,7 +338,7 @@ class StatusDetails(urwid.Pile):
             yield ("pack", urwid.Divider())
 
         # Show content warning
-        if status.data["spoiler_text"] and not status.show_sensitive:
+        if status.data["spoiler_text"] and not status.show_sensitive and not self.options.always_show_sensitive:
             yield ("pack", urwid.Text(("content_warning", "Marked as sensitive. Press S to view.")))
         else:
             if status.data["spoiler_text"]:

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -340,6 +340,9 @@ class StatusDetails(urwid.Pile):
         if status.data["spoiler_text"] and not status.show_sensitive:
             yield ("pack", urwid.Text(("content_warning", "Marked as sensitive. Press S to view.")))
         else:
+            if status.data["spoiler_text"]:
+                yield ("pack", urwid.Text(("content_warning", "Marked as sensitive.")))
+
             content = status.original.translation if status.original.show_translation else status.data["content"]
             widgetlist = html_to_widgets(content)
 


### PR DESCRIPTION
- Add an option to expand CWs automatically.
- Display the CW notice even on expanded toot, so it's still there even when this option is enabled.