### PR TITLE
tui: allow editing toots

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -230,12 +230,67 @@ def post_status(
     return http.post(app, user, '/api/v1/statuses', json=data, headers=headers)
 
 
+def edit_status(
+    app,
+    user,
+    id,
+    status,
+    visibility='public',
+    media_ids=None,
+    sensitive=False,
+    spoiler_text=None,
+    in_reply_to_id=None,
+    language=None,
+    content_type=None,
+    poll_options=None,
+    poll_expires_in=None,
+    poll_multiple=None,
+    poll_hide_totals=None,
+) -> Response:
+    """
+    Edit an existing status
+    https://docs.joinmastodon.org/methods/statuses/#edit
+    """
+
+    # Strip keys for which value is None
+    # Sending null values doesn't bother Mastodon, but it breaks Pleroma
+    data = drop_empty_values({
+        'status': status,
+        'media_ids': media_ids,
+        'visibility': visibility,
+        'sensitive': sensitive,
+        'in_reply_to_id': in_reply_to_id,
+        'language': language,
+        'content_type': content_type,
+        'spoiler_text': spoiler_text,
+    })
+
+    if poll_options:
+        data["poll"] = {
+            "options": poll_options,
+            "expires_in": poll_expires_in,
+            "multiple": poll_multiple,
+            "hide_totals": poll_hide_totals,
+        }
+
+    return http.put(app, user, f"/api/v1/statuses/{id}", json=data)
+
+
 def fetch_status(app, user, id):
     """
     Fetch a single status
     https://docs.joinmastodon.org/methods/statuses/#get
     """
     return http.get(app, user, f"/api/v1/statuses/{id}")
+
+
+def fetch_status_source(app, user, id):
+    """
+    Fetch the source (original text) for a single status.
+    This only works on local toots.
+    https://docs.joinmastodon.org/methods/statuses/#source
+    """
+    return http.get(app, user, f"/api/v1/statuses/{id}/source")
 
 
 def scheduled_statuses(app, user):

--- a/toot/cli/__init__.py
+++ b/toot/cli/__init__.py
@@ -5,7 +5,6 @@ import sys
 import typing as t
 
 from click.shell_completion import CompletionItem
-from click.testing import Result
 from click.types import StringParamType
 from functools import wraps
 

--- a/toot/http.py
+++ b/toot/http.py
@@ -38,7 +38,7 @@ def _get_error_message(response):
     except Exception:
         pass
 
-    return "Unknown error"
+    return f"Unknown error: {response.status_code} {response.reason}"
 
 
 def process_response(response):
@@ -79,6 +79,22 @@ def post(app, user, path, headers=None, files=None, data=None, json=None, allow_
     headers["Authorization"] = f"Bearer {user.access_token}"
 
     return anon_post(url, headers=headers, files=files, data=data, json=json, allow_redirects=allow_redirects)
+
+
+def anon_put(url, headers=None, files=None, data=None, json=None, allow_redirects=True):
+    request = Request(method="PUT", url=url, headers=headers, files=files, data=data, json=json)
+    response = send_request(request, allow_redirects)
+
+    return process_response(response)
+
+
+def put(app, user, path, headers=None, files=None, data=None, json=None, allow_redirects=True):
+    url = app.base_url + path
+
+    headers = headers or {}
+    headers["Authorization"] = f"Bearer {user.access_token}"
+
+    return anon_put(url, headers=headers, files=files, data=data, json=json, allow_redirects=allow_redirects)
 
 
 def patch(app, user, path, headers=None, files=None, data=None, json=None):

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -101,6 +101,7 @@ class Timeline(urwid.Columns):
             "[A]ccount" if not status.is_mine else "",
             "[B]oost",
             "[D]elete" if status.is_mine else "",
+            "[E]dit" if status.is_mine else "",
             "B[o]okmark",
             "[F]avourite",
             "[V]iew",
@@ -187,6 +188,11 @@ class Timeline(urwid.Columns):
         if key in ("d", "D"):
             if status.is_mine:
                 self.tui.show_delete_confirmation(status)
+            return
+
+        if key in ("e", "E"):
+            if status.is_mine:
+                self.tui.async_edit(status)
             return
 
         if key in ("f", "F"):

--- a/toot/tui/widgets.py
+++ b/toot/tui/widgets.py
@@ -67,3 +67,11 @@ class RadioButton(urwid.AttrWrap):
         button = urwid.RadioButton(*args, **kwargs)
         padding = urwid.Padding(button, width=len(args[1]) + 4)
         return super().__init__(padding, "button", "button_focused")
+
+
+class ModalBox(urwid.Frame):
+    def __init__(self, message):
+        text = urwid.Text(message)
+        filler = urwid.Filler(text, valign='top', top=1, bottom=1)
+        padding = urwid.Padding(filler, left=1, right=1)
+        return super().__init__(padding)


### PR DESCRIPTION
Add new [E]dit command to the timeline: opens an existing toot to allow editing it.  Since this is more or less the same operation as posting a new toot, extend the StatusComposer view to support this rather than implementing a new view.

---

~~this is a draft PR because of a significant unsolved issue: the Mastodon API returns toots as HTML, not plain text, so we would need to strip the HTML from the toot before displaying it in StatusComposer.  this is particularly difficult for toots with links or embeds.  i'm wondering if the API provides a better way to do this, but i couldn't find anything obvious in the docs.~~

~~aside from that, not all of the toot options are copied to the edited toot right now (i'll fix this)~~, and it could also do with more testing.

~~also, the edited toot currently doesn't show up on the timeline without a refresh.~~