### PR TITLE
tui: fix display glitch for reply icon in timeline

### DIFF
--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -456,7 +456,7 @@ class StatusListItem(SelectableColumns):
         favourited = ("highlight", "★") if status.original.favourited else " "
         reblogged = ("highlight", "♺") if status.original.reblogged else " "
         is_reblog = ("dim", "♺") if status.reblog else " "
-        is_reply = ("dim", "⤶") if status.original.in_reply_to else " "
+        is_reply = ("dim", "⤶ ") if status.original.in_reply_to else "  "
 
         return super().__init__([
             ("pack", SelectableText(("status_list_timestamp", created_at), wrap="clip")),


### PR DESCRIPTION
In some fonts, "⤶" (U+2936 ARROW POINTING DOWNWARDS THEN CURVING LEFTWARDS) may be a double-width character.  To avoid a display glitch where this overlaps with the boosted icon, print a space after it.