### PR TITLE
tui: show edit date in toot view

### DIFF
--- a/toot/tui/entities.py
+++ b/toot/tui/entities.py
@@ -53,6 +53,10 @@ class Status:
         self.id = self.data["id"]
         self.account = self._get_account()
         self.created_at = parse_datetime(data["created_at"])
+        if data["edited_at"]:
+            self.edited_at = parse_datetime(data["edited_at"])
+        else:
+            self.edited_at = None
         self.author = self._get_author()
         self.favourited = data.get("favourited", False)
         self.reblogged = data.get("reblogged", False)

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -388,6 +388,8 @@ class StatusDetails(urwid.Pile):
 
         yield ("pack", urwid.Text([
             ("status_detail_timestamp", f"{status.created_at.strftime('%Y-%m-%d %H:%M')} "),
+            ("status_detail_timestamp",
+             f"(edited {status.edited_at.strftime('%Y-%m-%d %H:%M')}) " if status.edited_at else ""),
             ("status_detail_bookmarked" if status.bookmarked else "dim", "b "),
             ("dim", f"⤶ {status.data['replies_count']} "),
             ("highlight" if status.reblogged else "dim", f"♺ {status.data['reblogs_count']} "),
@@ -442,7 +444,7 @@ class StatusDetails(urwid.Pile):
 
 class StatusListItem(SelectableColumns):
     def __init__(self, status, relative_datetimes):
-        edited_at = status.data.get("edited_at")
+        edited_at = status.original.edited_at
 
         # TODO: hacky implementation to avoid creating conflicts for existing
         # pull reuqests, refactor when merged.


### PR DESCRIPTION
When viewing a toot which has been edited, show the edit date.

While here, fix a bug where the '*' edit marker in the timeline wouldn't show for retoots because it was checking the retoot status instead of the original status.