### PR TITLE
tui: honour user's default visibility preference

### DIFF
--- a/toot/api.py
+++ b/toot/api.py
@@ -618,6 +618,10 @@ def get_instance(base_url: str) -> Response:
     return http.anon_get(url)
 
 
+def get_preferences(app, user) -> Response:
+    return http.get(app, user, '/api/v1/preferences')
+
+
 def get_lists(app, user):
     return http.get(app, user, "/api/v1/lists").json()
 

--- a/toot/cli/tui.py
+++ b/toot/cli/tui.py
@@ -1,7 +1,7 @@
 import click
 
 from typing import Optional
-from toot.cli import TUI_COLORS, Context, cli, pass_context
+from toot.cli import TUI_COLORS, VISIBILITY_CHOICES, Context, cli, pass_context
 from toot.cli.validators import validate_tui_colors
 from toot.tui.app import TUI, TuiOptions
 
@@ -24,12 +24,18 @@ COLOR_OPTIONS = ", ".join(TUI_COLORS.keys())
     help=f"""Number of colors to use, one of {COLOR_OPTIONS}, defaults to 16 if
              using --color, and 1 if using --no-color."""
 )
+@click.option(
+    "-v", "--default-visibility",
+    type=click.Choice(VISIBILITY_CHOICES),
+    help="Default visibility when posting new toots; overrides the server-side preference"
+)
 @pass_context
 def tui(
     ctx: Context,
     colors: Optional[int],
     media_viewer: Optional[str],
     relative_datetimes: bool,
+    default_visibility: Optional[str]
 ):
     """Launches the toot terminal user interface"""
     if colors is None:
@@ -39,6 +45,7 @@ def tui(
         colors=colors,
         media_viewer=media_viewer,
         relative_datetimes=relative_datetimes,
+        default_visibility=default_visibility
     )
     tui = TUI.create(ctx.app, ctx.user, options)
     tui.run()

--- a/toot/tui/compose.py
+++ b/toot/tui/compose.py
@@ -1,8 +1,6 @@
 import urwid
 import logging
 
-from toot.cli import get_default_visibility
-
 from .constants import VISIBILITY_OPTIONS
 from .widgets import Button, EditBox
 
@@ -15,7 +13,7 @@ class StatusComposer(urwid.Frame):
     """
     signals = ["close", "post"]
 
-    def __init__(self, max_chars, username, in_reply_to=None):
+    def __init__(self, max_chars, username, visibility, in_reply_to=None):
         self.in_reply_to = in_reply_to
         self.max_chars = max_chars
         self.username = username
@@ -34,7 +32,7 @@ class StatusComposer(urwid.Frame):
             on_press=self.remove_content_warning)
 
         self.visibility = (
-            in_reply_to.visibility if in_reply_to else get_default_visibility()
+            in_reply_to.visibility if in_reply_to else visibility
         )
         self.visibility_button = Button("Visibility: {}".format(self.visibility),
             on_press=self.choose_visibility)


### PR DESCRIPTION
Mastodon allows the user to configure a default visibility which should apply to all clients.  This setting is returned by the /api/v1/preferences method.

Fetch the user preferences when the TUI starts, and use it to set the default visibility when composing a new toot.  If the preference is not found, fall back to get_default_visibility().