### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog
 * Honour user's default visibility set in Mastodon preferences instead of always
   defaulting to public visibility (thanks Lexi Winter)
 * TUI: Add editing toots (thanks Lexi Winter)
-* TUI: Fix a bug which made pallette config in settings not work
+* TUI: Fix a bug which made palette config in settings not work
 * TUI: Show edit datetime in status detail (thanks Lexi Winter)
 
 **0.40.2 (2023-12-28)**
@@ -49,7 +49,7 @@ mostly preserved, except for cases noted below. Please report any issues.
   list`, `lists remove` subcommands, deprecate `lists`, `lists_accounts`,
   `lists_add`, `lists_create`, `lists_delete`, `lists_remove` commands.
 * Add `--json` option to tags and lists commands
-* Add `toot --width` option for setting your prefered terminal width
+* Add `toot --width` option for setting your preferred terminal width
 * Add `--media-viewer` and `--colors` options to `toot tui`. These were
   previously accessible only via settings.
 * TUI: Fix issue where UI did not render until first input (thanks Urwid devs)
@@ -144,7 +144,7 @@ mostly preserved, except for cases noted below. Please report any issues.
 * TUI: Hide polls, cards and media attachments for sensitive posts (thanks
   Daniel Schwarz)
 * TUI: Add bookmarking and bookmark timeline (thanks Daniel Schwarz)
-* TUI: Show status visiblity (thanks Lim Ding Wen)
+* TUI: Show status visibility (thanks Lim Ding Wen)
 * TUI: Reply to original account instead of boosting account (thanks Lim Ding
   Wen)
 * TUI: Refresh screen after exiting browser, required for text browsers (thanks
@@ -172,7 +172,7 @@ mostly preserved, except for cases noted below. Please report any issues.
 
 **0.30.1 (2022-11-30)**
 
-* Remove usage of depreacted `text_url` status field. Fixes posting media
+* Remove usage of deprecated `text_url` status field. Fixes posting media
   without text.
 
 **0.30.0 (2022-11-29)**
@@ -225,7 +225,7 @@ mostly preserved, except for cases noted below. Please report any issues.
   (#168)
 * Add `--reverse` option to `toot notifications` (#151)
 * Fix `toot timeline` to respect `--instance` option
-* TUI: Add opton to pin/save tag timelines (#163, thanks @dlax)
+* TUI: Add option to pin/save tag timelines (#163, thanks @dlax)
 * TUI: Fixed crash on empty timeline (#138, thanks ecs)
 
 **0.26.0 (2020-04-15)**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ these rules for you.
 
 #### Run tests before submitting
 
-You can run code and sytle tests by running:
+You can run code and style tests by running:
 
 ```
 make test

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -8,7 +8,7 @@
   changes:
     - "Honour user's default visibility set in Mastodon preferences instead of always defaulting to public visibility (thanks Lexi Winter)"
     - "TUI: Add editing toots (thanks Lexi Winter)"
-    - "TUI: Fix a bug which made pallette config in settings not work"
+    - "TUI: Fix a bug which made palette config in settings not work"
     - "TUI: Show edit datetime in status detail (thanks Lexi Winter)"
 
 0.40.2:
@@ -41,7 +41,7 @@
     - "Add `tags followed`, `tags follow`, and `tags unfollow` sub-commands, deprecate `tags_followed`, `tags_follow`, and `tags tags_unfollow`"
     - "Add `lists accounts`, `lists add`, `lists create`, `lists delete`, `lists list`, `lists remove` subcommands, deprecate `lists`, `lists_accounts`, `lists_add`, `lists_create`, `lists_delete`, `lists_remove` commands."
     - "Add `--json` option to tags and lists commands"
-    - "Add `toot --width` option for setting your prefered terminal width"
+    - "Add `toot --width` option for setting your preferred terminal width"
     - "Add `--media-viewer` and `--colors` options to `toot tui`. These were previously accessible only via settings."
     - "TUI: Fix issue where UI did not render until first input (thanks Urwid devs)"
 
@@ -133,7 +133,7 @@
     - "TUI: Show an error if attemptint to boost a private status (thanks Lim Ding Wen)"
     - "TUI: Hide polls, cards and media attachments for sensitive posts (thanks Daniel Schwarz)"
     - "TUI: Add bookmarking and bookmark timeline (thanks Daniel Schwarz)"
-    - "TUI: Show status visiblity (thanks Lim Ding Wen)"
+    - "TUI: Show status visibility (thanks Lim Ding Wen)"
     - "TUI: Reply to original account instead of boosting account (thanks Lim Ding Wen)"
     - "TUI: Refresh screen after exiting browser, required for text browsers (thanks Daniel Schwarz)"
     - "TUI: Highlight followed tags (thanks Daniel Schwarz)"
@@ -161,7 +161,7 @@
 0.30.1:
   date: 2022-11-30
   changes:
-    - "Remove usage of depreacted `text_url` status field. Fixes posting media without text."
+    - "Remove usage of deprecated `text_url` status field. Fixes posting media without text."
 
 0.30.0:
   date: 2022-11-29
@@ -208,7 +208,7 @@
     - "TUI: Fix access to public and tag timelines when on private mastodon instances (#168)"
     - "Add `--reverse` option to `toot notifications` (#151)"
     - "Fix `toot timeline` to respect `--instance` option"
-    - "TUI: Add opton to pin/save tag timelines (#163, thanks @dlax)"
+    - "TUI: Add option to pin/save tag timelines (#163, thanks @dlax)"
     - "TUI: Fixed crash on empty timeline (#138, thanks ecs)"
 
 0.26.0:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ Changelog
 * Honour user's default visibility set in Mastodon preferences instead of always
   defaulting to public visibility (thanks Lexi Winter)
 * TUI: Add editing toots (thanks Lexi Winter)
-* TUI: Fix a bug which made pallette config in settings not work
+* TUI: Fix a bug which made palette config in settings not work
 * TUI: Show edit datetime in status detail (thanks Lexi Winter)
 
 **0.40.2 (2023-12-28)**
@@ -49,7 +49,7 @@ mostly preserved, except for cases noted below. Please report any issues.
   list`, `lists remove` subcommands, deprecate `lists`, `lists_accounts`,
   `lists_add`, `lists_create`, `lists_delete`, `lists_remove` commands.
 * Add `--json` option to tags and lists commands
-* Add `toot --width` option for setting your prefered terminal width
+* Add `toot --width` option for setting your preferred terminal width
 * Add `--media-viewer` and `--colors` options to `toot tui`. These were
   previously accessible only via settings.
 * TUI: Fix issue where UI did not render until first input (thanks Urwid devs)
@@ -144,7 +144,7 @@ mostly preserved, except for cases noted below. Please report any issues.
 * TUI: Hide polls, cards and media attachments for sensitive posts (thanks
   Daniel Schwarz)
 * TUI: Add bookmarking and bookmark timeline (thanks Daniel Schwarz)
-* TUI: Show status visiblity (thanks Lim Ding Wen)
+* TUI: Show status visibility (thanks Lim Ding Wen)
 * TUI: Reply to original account instead of boosting account (thanks Lim Ding
   Wen)
 * TUI: Refresh screen after exiting browser, required for text browsers (thanks
@@ -172,7 +172,7 @@ mostly preserved, except for cases noted below. Please report any issues.
 
 **0.30.1 (2022-11-30)**
 
-* Remove usage of depreacted `text_url` status field. Fixes posting media
+* Remove usage of deprecated `text_url` status field. Fixes posting media
   without text.
 
 **0.30.0 (2022-11-29)**
@@ -225,7 +225,7 @@ mostly preserved, except for cases noted below. Please report any issues.
   (#168)
 * Add `--reverse` option to `toot notifications` (#151)
 * Fix `toot timeline` to respect `--instance` option
-* TUI: Add opton to pin/save tag timelines (#163, thanks @dlax)
+* TUI: Add option to pin/save tag timelines (#163, thanks @dlax)
 * TUI: Fixed crash on empty timeline (#138, thanks ecs)
 
 **0.26.0 (2020-04-15)**

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -118,7 +118,7 @@ these rules for you.
 
 #### Run tests before submitting
 
-You can run code and sytle tests by running:
+You can run code and style tests by running:
 
 ```
 make test

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -11,7 +11,7 @@ Toot will look for the settings file at:
 * `~/.config/toot/settings.toml` (Linux & co.)
 * `%APPDATA%\toot\settings.toml` (Windows)
 
-Toot will respect the `XDG_CONFIG_HOME` environement variable if it's set and
+Toot will respect the `XDG_CONFIG_HOME` environment variable if it's set and
 look for the settings file in `$XDG_CONFIG_HOME/toot` instead of
 `~/.config/toot`.
 
@@ -82,7 +82,7 @@ By default, TUI operates in 16-color mode which can be changed by setting the
 * `16777216` (24 bit)
 
 TUI defines a list of colors which can be customized, currently they can be seen
-[in the source code](https://github.com/ihabunek/toot/blob/master/toot/tui/constants.py). They can be overriden in the `[tui.palette]` section.
+[in the source code](https://github.com/ihabunek/toot/blob/master/toot/tui/constants.py). They can be overridden in the `[tui.palette]` section.
 
 Each color is defined as a list of upto 5 values:
 

--- a/tests/integration/test_accounts.py
+++ b/tests/integration/test_accounts.py
@@ -36,7 +36,7 @@ def test_whois(app: App, friend: User, run):
 
 
 def test_following(app: App, user: User, friend: User, friend_id, run):
-    # Make sure we're not initally following friend
+    # Make sure we're not initially following friend
     api.unfollow(app, user, friend_id)
 
     result = run(cli.accounts.following, user.username)
@@ -85,7 +85,7 @@ def test_following_not_found(run):
 
 
 def test_following_json(app: App, user: User, friend: User, user_id, friend_id, run_json):
-    # Make sure we're not initally following friend
+    # Make sure we're not initially following friend
     api.unfollow(app, user, friend_id)
 
     result = run_json(cli.accounts.following, user.username, "--json")

--- a/tests/integration/test_timelines.py
+++ b/tests/integration/test_timelines.py
@@ -8,7 +8,7 @@ from toot.entities import from_dict, Status
 from tests.integration.conftest import TOOT_TEST_BASE_URL, register_account
 
 
-# TODO: If fixture is not overriden here, tests fail, not sure why, figure it out
+# TODO: If fixture is not overridden here, tests fail, not sure why, figure it out
 @pytest.fixture(scope="module")
 def user(app):
     return register_account(app)

--- a/toot/tui/constants.py
+++ b/toot/tui/constants.py
@@ -46,7 +46,7 @@ PALETTE = [
     ('shortcut_highlight', 'white,bold', '', 'bold'),
     ('warning', 'light red', ''),
 
-    # Visiblity
+    # Visibility
     ('visibility_public', 'dark gray', ''),
     ('visibility_unlisted', 'white', ''),
     ('visibility_private', 'dark cyan', ''),

--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -85,7 +85,7 @@ class Timeline(urwid.Columns):
         return urwid.AttrMap(item, None, focus_map={
             "status_list_account": "status_list_selected",
             "status_list_timestamp": "status_list_selected",
-            "highligh": "status_list_selected",
+            "highlight": "status_list_selected",
             "dim": "status_list_selected",
             None: "status_list_selected",
         })
@@ -457,7 +457,7 @@ class StatusListItem(SelectableColumns):
         edited_at = status.original.edited_at
 
         # TODO: hacky implementation to avoid creating conflicts for existing
-        # pull reuqests, refactor when merged.
+        # pull requests, refactor when merged.
         created_at = (
             time_ago(status.created_at).ljust(3, " ")
             if relative_datetimes


### PR DESCRIPTION
Found via `codespell -L fo,te,oll`