### PR TITLE
EditBox now uses urwid_readline library. Fixes #353

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
         "beautifulsoup4>=4.5.0,<5.0",
         "wcwidth>=0.1.7",
         "urwid>=2.0.0,<3.0",
-        "tomlkit>=0.10.0,<1.0"
+        "tomlkit>=0.10.0,<1.0",
+        "urwid_readline>=0.14"
     ],
     extras_require={
         # Required to display rich text in the TUI

--- a/toot/tui/widgets.py
+++ b/toot/tui/widgets.py
@@ -1,4 +1,5 @@
 import urwid
+import urwid_readline
 from wcwidth import wcswidth
 
 
@@ -33,7 +34,7 @@ class SelectableColumns(Clickable, urwid.Columns):
 class EditBox(urwid.AttrWrap):
     """Styled edit box."""
     def __init__(self, *args, **kwargs):
-        self.edit = urwid.Edit(*args, **kwargs)
+        self.edit = urwid_readline.ReadlineEdit(*args, **kwargs)
         return super().__init__(self.edit, "editbox", "editbox_focused")
 
 


### PR DESCRIPTION
The urwid_readline library allows readline style key commands. Equivalent to readline with set -o emacs. ctrl-a, ctrl-e, ctrl-k, etc.
The library doesn't have a mode equivalent to set -o vi, unfortunately, but this will add functionality sufficient to fix 353.