### PR TITLE
Added safeguards to prevent crashes when rendering corrupt URLs

### DIFF
--- a/toot/tui/richtext/richtext.py
+++ b/toot/tui/richtext/richtext.py
@@ -60,7 +60,10 @@ def html_to_widgets(html, recovery_attempt=False) -> List[urwid.Widget]:
 
 
 def url_to_widget(url: str):
-    widget = len(url), urwid.Filler(Hyperlink(url, "link", url))
+    try:
+        widget = len(url), urwid.Filler(Hyperlink(url, "link", url))
+    except ValueError:
+        widget = len(url), urwid.Filler(urwid.Text(url))  # don't style as link
     return TextEmbed(widget)
 
 
@@ -98,10 +101,16 @@ def text_to_widget(attr, markup) -> urwid.Widget:
             if match:
                 label, url = match.groups()
                 anchor_attr = get_best_anchor_attr(attr_list)
-                markup_list.append((
-                    len(label),
-                    urwid.Filler(Hyperlink(url, anchor_attr, label)),
-                ))
+                try:
+                    markup_list.append((
+                        len(label),
+                        urwid.Filler(Hyperlink(url, anchor_attr, label)),
+                    ))
+                except ValueError:
+                    markup_list.append((
+                        len(label),
+                        urwid.Filler(urwid.Text(url)),  # don't style as link
+                    ))
             else:
                 markup_list.append(run)
         else:


### PR DESCRIPTION
Urwidgets' `Hyperlink` widget (correctly) throws an exception when presented with a URL containing disallowed characters (i.e. control characters.) If we get a corrupt URL in a status posting, this will cause a crash.  An example of such a status is [here](https://journa.host/@lolgop/112060018386619213). If this loads in the TUI today, ,it will crash.

With this PR, we will react to corrupt URLs by rendering as `urwid.Text` rather than `Hyperlink` and there will be no crash.

Given the recent comments about switching to tooi, this will probably be the last PR I submit for the toot tui.  It makes more sense to focus efforts on the tooi front end.