### PR TITLE
Fixes the KeyError for edited_at launch

### DIFF
--- a/toot/tui/entities.py
+++ b/toot/tui/entities.py
@@ -53,10 +53,7 @@ class Status:
         self.id = self.data["id"]
         self.account = self._get_account()
         self.created_at = parse_datetime(data["created_at"])
-        if data.get("edited_at"):
-            self.edited_at = parse_datetime(data["edited_at"])
-        else:
-            self.edited_at = None
+        self.edited_at = parse_datetime(data.get("edited_at")) if data.get("edited_at") else None
         self.author = self._get_author()
         self.favourited = data.get("favourited", False)
         self.reblogged = data.get("reblogged", False)


### PR DESCRIPTION
I saw an error preventing launching toot on my GoToSocial instance:

`File "/usr/lib/python3.11/site-packages/toot/tui/entities.py", line 56, in __init__
    if data["edited_at"]:
^^^^^^^^^^^^^^^^^
KeyError: 'edited_at'
An exception occurred, press X to view`

Seeing how `self.created_at` was being handled, I implemented the same kind of handling to `self.edited_at` including the original logic which fixed the launching issue at the same go.