### PR TITLE
Fix reversion error; restore minimum urwidgets version to be 0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ images = [
 
 # Required to display rich text in the TUI
 richtext = [
-    "urwidgets>=0.1,<0.2"
+    "urwidgets>=0.2,<0.3"
 ]
 
 test = [


### PR DESCRIPTION
Addresses the first issue reported in issue #481 