### PR TITLE
Improve Image Support

### DIFF
--- a/toot/tui/images.py
+++ b/toot/tui/images.py
@@ -28,7 +28,6 @@ try:
         global _ImageCls
 
         if not _ImageCls:
-            BaseImage.forced_support = True
             _ImageCls = (
                 KittyImage
                 if image_format == 'kitty'
@@ -36,6 +35,7 @@ try:
                 if image_format == 'iterm'
                 else BlockImage
             )
+            _ImageCls.forced_support = True
 
         return _ImageCls(image)
 

--- a/toot/tui/images.py
+++ b/toot/tui/images.py
@@ -10,6 +10,8 @@ try:
     from term_image import disable_queries  # prevent phantom keystrokes
     from PIL import Image, ImageDraw
 
+    _IMAGE_PIXEL_FORMATS = frozenset({'kitty', 'iterm'})
+
     TuiScreen = UrwidImageScreen
     disable_queries()
 
@@ -17,7 +19,7 @@ try:
         return True
 
     def can_render_pixels(image_format):
-        return image_format in ['kitty', 'iterm']
+        return image_format in _IMAGE_PIXEL_FORMATS
 
     def get_base_image(image, image_format) -> BaseImage:
         # we don't autodetect kitty, iterm; we choose based on option switches

--- a/toot/tui/images.py
+++ b/toot/tui/images.py
@@ -11,6 +11,7 @@ try:
     from PIL import Image, ImageDraw
 
     _IMAGE_PIXEL_FORMATS = frozenset({'kitty', 'iterm'})
+    _ImageCls = None
 
     TuiScreen = UrwidImageScreen
     disable_queries()
@@ -23,13 +24,20 @@ try:
 
     def get_base_image(image, image_format) -> BaseImage:
         # we don't autodetect kitty, iterm; we choose based on option switches
-        BaseImage.forced_support = True
-        if image_format == 'kitty':
-            return KittyImage(image)
-        elif image_format == 'iterm':
-            return ITerm2Image(image)
-        else:
-            return BlockImage(image)
+
+        global _ImageCls
+
+        if not _ImageCls:
+            BaseImage.forced_support = True
+            _ImageCls = (
+                KittyImage
+                if image_format == 'kitty'
+                else ITerm2Image
+                if image_format == 'iterm'
+                else BlockImage
+            )
+
+        return _ImageCls(image)
 
     def resize_image(basewidth: int, baseheight: int, img: Image.Image) -> Image.Image:
         if baseheight and not basewidth:


### PR DESCRIPTION
- Fixes kitty graphics control sequences being displayed in iTerm2's title bar when image support is enabled.
- Optimizes image class selection.
- Optimizes image format pixel support detection.

The iTerm2 issue was brought to my attention by @danschwarz in https://github.com/AnonymouX47/term-image/issues/90#issuecomment-2144037780:

> Interestingly, the window title of the iTerm window has a part of a terminal command sequence in it, not sure what that's about.

The optimization changes were just things I noticed along the way.