### PR TITLE
Added 'toot diag' command that outputs useful diagnostic info

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-exclude=build,tests,tmp,venv,toot/tui/scroll.py
+exclude=build,tests,tmp,venv,_env,toot/tui/scroll.py
 ignore=E128,W503,W504
 max-line-length=120

--- a/toot/cli/__init__.py
+++ b/toot/cli/__init__.py
@@ -173,6 +173,7 @@ def cli(ctx: click.Context, max_width: int, color: bool, debug: bool, as_user: s
 
 from toot.cli import accounts  # noqa
 from toot.cli import auth  # noqa
+from toot.cli import diag  # noqa
 from toot.cli import lists  # noqa
 from toot.cli import post  # noqa
 from toot.cli import read  # noqa

--- a/toot/cli/diag.py
+++ b/toot/cli/diag.py
@@ -1,3 +1,4 @@
+import click
 from toot.output import print_diags
 from toot.cli import (
     cli,
@@ -7,8 +8,14 @@ from toot.cli import (
 
 
 @cli.command()
+@click.option(
+    "-f",
+    "--files",
+    is_flag=True,
+    help="Print contents of the config and settings files in diagnostic output",
+)
 @pass_context
-def diag(ctx: Context):
+def diag(ctx: Context, files: bool):
     """Display useful information for diagnosing problems"""
 
-    print_diags()
+    print_diags(files)

--- a/toot/cli/diag.py
+++ b/toot/cli/diag.py
@@ -1,4 +1,5 @@
 import click
+from toot import api
 from toot.output import print_diags
 from toot.cli import (
     cli,
@@ -14,8 +15,15 @@ from toot.cli import (
     is_flag=True,
     help="Print contents of the config and settings files in diagnostic output",
 )
+@click.option(
+    "-s",
+    "--server",
+    is_flag=True,
+    help="Print information about the curren server in diagnostic output",
+)
 @pass_context
-def diag(ctx: Context, files: bool):
+def diag(ctx: Context, files: bool, server: bool):
     """Display useful information for diagnosing problems"""
 
-    print_diags(files)
+    instance_dict = api.get_instance(ctx.app.base_url).json() if server else None
+    print_diags(instance_dict, files)

--- a/toot/cli/diag.py
+++ b/toot/cli/diag.py
@@ -1,0 +1,14 @@
+from toot.output import print_diags
+from toot.cli import (
+    cli,
+    pass_context,
+    Context,
+)
+
+
+@cli.command()
+@pass_context
+def diag(ctx: Context):
+    """Display useful information for diagnosing problems"""
+
+    print_diags()

--- a/toot/output.py
+++ b/toot/output.py
@@ -325,7 +325,31 @@ def print_diags():
 
     from toot import __version__, config, settings
     click.echo(f'{green(f"Toot version:")} {__version__}')
-        
+
+    click.echo(f'{green(f"Settings path:")} {settings.get_settings_path()}')
+    click.echo(f'{green(f"Settings file contents:")}')
+    try:
+        with open(settings.get_settings_path(), 'r') as f:
+            print(f.read())
+    except:  # noqa
+        click.echo(f'{yellow(f"Could not open settings file")}')
+
+    click.echo('')
+
+    click.echo(f'{green(f"Config path:")} {config.get_config_file_path()}')
+    click.echo(f'{green(f"Config file contents:")}')
+    try:
+        with open(config.get_config_file_path(), 'r') as f:
+            for line in f:
+                if "client_" not in line and "token" not in line:
+                    click.echo(line, nl=False)
+                else:
+                    click.echo(f'{yellow("***LINE REDACTED***")}')
+    except:  # noqa
+        click.echo(f'{yellow(f"Could not open config file")}')
+
+    click.echo('')
+
     import platform
     click.echo(f'{green(f"Platform:")} {platform.platform()}')
 

--- a/toot/output.py
+++ b/toot/output.py
@@ -323,6 +323,9 @@ def print_diags():
     now = datetime.now(timezone.utc)
     click.echo(f'{green("Current Date/Time:")} {now.strftime("%Y-%m-%d %H:%M:%S %Z")}')
 
+    from toot import __version__, config, settings
+    click.echo(f'{green(f"Toot version:")} {__version__}')
+        
     import platform
     click.echo(f'{green(f"Platform:")} {platform.platform()}')
 

--- a/toot/output.py
+++ b/toot/output.py
@@ -314,6 +314,41 @@ def format_account_name(account: Account) -> str:
         return acct
 
 
+def print_diags():
+    from importlib.metadata import version
+
+    click.echo(f'{green(f"Diagnostic Information")}')
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    click.echo(f'{green("Current Date/Time:")} {now.strftime("%Y-%m-%d %H:%M:%S %Z")}')
+
+    import platform
+    click.echo(f'{green(f"Platform:")} {platform.platform()}')
+
+# Uncomment this when we move to minimum Python version 3.10
+#    try:
+#        name = platform.freedesktop_os_release()['PRETTY_NAME']
+#        click.echo(f'{green(f"Distro:")} {name}')
+#    except:  # noqa
+#        pass
+
+    click.echo(f'{green(f"Python version:")} {platform.python_version()}')
+    click.echo(green("Dependency versions:"))
+
+    deps = ['beautifulsoup4', 'click', 'requests', 'tomlkit', 'urwid', 'wcwidth',
+            'pillow', 'term-image', 'urwidgets', 'flake8', 'pytest', 'setuptools',
+            'vermin', 'typing-extensions']
+
+    for dep in deps:
+        try:
+            ver = version(dep)
+        except:  # noqa
+            ver = yellow("not installed")
+
+        click.echo(f"\t{dep}: {ver}")
+
+
 # Shorthand functions for coloring output
 
 def blue(text: t.Any) -> str:

--- a/toot/output.py
+++ b/toot/output.py
@@ -329,12 +329,14 @@ def print_diags(include_files: bool):
     import platform
     click.echo(f'{green(f"Platform:")} {platform.platform()}')
 
-# Uncomment this when we move to minimum Python version 3.10
-#    try:
-#        name = platform.freedesktop_os_release()['PRETTY_NAME']
-#        click.echo(f'{green(f"Distro:")} {name}')
-#    except:  # noqa
-#        pass
+    # print distro - only call if available (python 3.10+)
+    fd_os_release = getattr(platform, "freedesktop_os_release", None)  # novermin
+    if callable(fd_os_release):  # novermin
+        try:
+            name = platform.freedesktop_os_release()['PRETTY_NAME']
+            click.echo(f'{green(f"Distro:")} {name}')
+        except:  # noqa
+            pass
 
     click.echo(f'{green(f"Python version:")} {platform.python_version()}')
     click.echo(green("Dependency versions:"))

--- a/toot/output.py
+++ b/toot/output.py
@@ -314,7 +314,7 @@ def format_account_name(account: Account) -> str:
         return acct
 
 
-def print_diags():
+def print_diags(include_files: bool):
     from importlib.metadata import version
 
     click.echo(f'{green(f"Diagnostic Information")}')
@@ -325,30 +325,6 @@ def print_diags():
 
     from toot import __version__, config, settings
     click.echo(f'{green(f"Toot version:")} {__version__}')
-
-    click.echo(f'{green(f"Settings path:")} {settings.get_settings_path()}')
-    click.echo(f'{green(f"Settings file contents:")}')
-    try:
-        with open(settings.get_settings_path(), 'r') as f:
-            print(f.read())
-    except:  # noqa
-        click.echo(f'{yellow(f"Could not open settings file")}')
-
-    click.echo('')
-
-    click.echo(f'{green(f"Config path:")} {config.get_config_file_path()}')
-    click.echo(f'{green(f"Config file contents:")}')
-    try:
-        with open(config.get_config_file_path(), 'r') as f:
-            for line in f:
-                if "client_" not in line and "token" not in line:
-                    click.echo(line, nl=False)
-                else:
-                    click.echo(f'{yellow("***LINE REDACTED***")}')
-    except:  # noqa
-        click.echo(f'{yellow(f"Could not open config file")}')
-
-    click.echo('')
 
     import platform
     click.echo(f'{green(f"Platform:")} {platform.platform()}')
@@ -374,6 +350,34 @@ def print_diags():
             ver = yellow("not installed")
 
         click.echo(f"\t{dep}: {ver}")
+
+    click.echo(f'{green(f"Settings file path:")} {settings.get_settings_path()}')
+    click.echo(f'{green(f"Config file path:")} {config.get_config_file_path()}')
+
+    if include_files:
+        click.echo(f'{green(f"Settings file contents:")}')
+        try:
+            with open(settings.get_settings_path(), 'r') as f:
+                print(f.read())
+        except:  # noqa
+            click.echo(f'{yellow(f"Could not open settings file")}')
+
+            click.echo('')
+
+        click.echo(f'{green(f"Config file contents:")}')
+        try:
+            with open(config.get_config_file_path(), 'r') as f:
+                for line in f:
+                    # Do not output client secret or access token lines
+                    if "client_" in line or "token" in line:
+                        click.echo(f'{yellow("***CONTENTS REDACTED***")}')
+                    else:
+                        click.echo(line, nl=False)
+
+        except:  # noqa
+            click.echo(f'{yellow(f"Could not open config file")}')
+
+        click.echo('')
 
 
 # Shorthand functions for coloring output

--- a/toot/output.py
+++ b/toot/output.py
@@ -314,7 +314,7 @@ def format_account_name(account: Account) -> str:
         return acct
 
 
-def print_diags(include_files: bool):
+def print_diags(instance_dict: t.Dict, include_files: bool):
     from importlib.metadata import version
 
     click.echo(f'{green(f"Diagnostic Information")}')
@@ -355,6 +355,16 @@ def print_diags(include_files: bool):
 
     click.echo(f'{green(f"Settings file path:")} {settings.get_settings_path()}')
     click.echo(f'{green(f"Config file path:")} {config.get_config_file_path()}')
+
+    if instance_dict:
+        try:
+            click.echo(f'{green(f"Server URI:")} {instance_dict["uri"]}')
+        except:  # noqa E722
+            pass
+        try:
+            click.echo(f'{green(f"Server version:")} {instance_dict["version"]}')
+        except:  # noqa E722
+            pass
 
     if include_files:
         click.echo(f'{green(f"Settings file contents:")}')

--- a/toot/output.py
+++ b/toot/output.py
@@ -341,9 +341,9 @@ def print_diags(include_files: bool):
     click.echo(f'{green(f"Python version:")} {platform.python_version()}')
     click.echo(green("Dependency versions:"))
 
-    deps = ['beautifulsoup4', 'click', 'requests', 'tomlkit', 'urwid', 'wcwidth',
+    deps = sorted(['beautifulsoup4', 'click', 'requests', 'tomlkit', 'urwid', 'wcwidth',
             'pillow', 'term-image', 'urwidgets', 'flake8', 'pytest', 'setuptools',
-            'vermin', 'typing-extensions']
+            'vermin', 'typing-extensions'])
 
     for dep in deps:
         try:


### PR DESCRIPTION
![image](https://github.com/ihabunek/toot/assets/3261094/3994ce17-e9ad-4de2-88ab-0adc63fa5923)

with `-f` flag, displays redacted versions of config and settings files

![image](https://github.com/ihabunek/toot/assets/3261094/e38b542d-43df-4ad6-8382-01bc759ea898)
