### PR TITLE
Allow running tests with pytest-3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PYTEST = $(shell which pytest pytest-3 )
+
 .PHONY: clean publish test docs
 
 dist:
@@ -7,7 +9,7 @@ publish :
 	twine upload dist/*.tar.gz dist/*.whl
 
 test:
-	pytest -v
+	test -e "$(PYTEST)" && $(PYTEST) -v # run pytest if found
 	flake8
 	vermin toot
 


### PR DESCRIPTION
On Ubuntu-22.04 installing python3-pytest installs pytest-3 and there is no pytest. This change allows running the first found on the system.