### PR TITLE
Add alternate `redirect_uri` support for broken instances

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,6 +45,7 @@ def test_extract_active_user_app(sample_config):
     assert app.base_url == 'https://bar.social'
     assert app.client_id == 'ghi'
     assert app.client_secret == 'jkl'
+    assert app.redirect_uri == 'urn:ietf:wg:oauth:2.0:oob'
 
 
 def test_extract_active_when_no_active_user(sample_config):

--- a/toot/__init__.py
+++ b/toot/__init__.py
@@ -17,6 +17,7 @@ class App(NamedTuple):
     base_url: str
     client_id: str
     client_secret: str
+    redirect_uri: str
 
 
 class User(NamedTuple):

--- a/toot/api.py
+++ b/toot/api.py
@@ -77,12 +77,12 @@ def _tag_action(app, user, tag_name, action) -> Response:
     return http.post(app, user, url)
 
 
-def create_app(base_url):
+def create_app(base_url, redirect_uri):
     url = f"{base_url}/api/v1/apps"
 
     json = {
         'client_name': CLIENT_NAME,
-        'redirect_uris': 'urn:ietf:wg:oauth:2.0:oob',
+        'redirect_uris': redirect_uri,
         'scopes': SCOPES,
         'website': CLIENT_WEBSITE,
     }
@@ -157,7 +157,7 @@ def fetch_app_token(app):
         "client_id": app.client_id,
         "client_secret": app.client_secret,
         "grant_type": "client_credentials",
-        "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
+        "redirect_uri": app.redirect_uri,
         "scope": "read write"
     }
 
@@ -183,7 +183,7 @@ def get_browser_login_url(app: App) -> str:
     """Returns the URL for manual log in via browser"""
     return "{}/oauth/authorize/?{}".format(app.base_url, urlencode({
         "response_type": "code",
-        "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
+        "redirect_uri": app.redirect_uri,
         "scope": SCOPES,
         "client_id": app.client_id,
     }))
@@ -197,7 +197,7 @@ def request_access_token(app: App, authorization_code: str):
         'client_id': app.client_id,
         'client_secret': app.client_secret,
         'code': authorization_code,
-        'redirect_uri': 'urn:ietf:wg:oauth:2.0:oob',
+        'redirect_uri': app.redirect_uri,
     }
 
     return http.anon_post(url, data=data, allow_redirects=False).json()

--- a/toot/cli/auth.py
+++ b/toot/cli/auth.py
@@ -61,7 +61,9 @@ def login_cli(base_url: str, email: str, password: str):
     Does NOT support two factor authentication, may not work on instances
     other than Mastodon, mostly useful for scripting.
     """
-    app = get_or_create_app(base_url)
+    # blank `redirect_uri` will end up being OOB in the config but if
+    # we're doing a direct login, it doesn't matter.
+    app = get_or_create_app(base_url, '')
     login_username_password(app, email, password)
 
     click.secho("✓ Successfully logged in.", fg="green")
@@ -77,7 +79,8 @@ you need to paste here.""".replace("\n", " ")
 
 @cli.command()
 @instance_option
-@click.option("--redirect", "-r", "redirect_uri", help="Redirect URI to use instead of OOB", prompt=True, default="urn:ietf:wg:oauth:2.0:oob")
+@click.option("--redirect", "-r", "redirect_uri", help="Redirect URI to use instead of OOB",
+              prompt=True, default="urn:ietf:wg:oauth:2.0:oob")
 def login(base_url: str, redirect_uri: str):
     """Log into an instance using your browser (recommended)"""
     app = get_or_create_app(base_url, redirect_uri)

--- a/toot/cli/auth.py
+++ b/toot/cli/auth.py
@@ -77,9 +77,11 @@ you need to paste here.""".replace("\n", " ")
 
 @cli.command()
 @instance_option
-def login(base_url: str):
+@click.option("--redirect", "-r", "redirect_uri", help="Redirect URI to use instead of OOB", prompt=True, default="urn:ietf:wg:oauth:2.0:oob")
+def login(base_url: str, redirect_uri: str):
     """Log into an instance using your browser (recommended)"""
-    app = get_or_create_app(base_url)
+    app = get_or_create_app(base_url, redirect_uri)
+    # `redirect_uri` is now stored in `app` for future use / saving.
     url = api.get_browser_login_url(app)
 
     click.echo(click.wrap_text(LOGIN_EXPLANATION))

--- a/toot/config.py
+++ b/toot/config.py
@@ -69,6 +69,11 @@ def extract_user_app(config, user_id: str):
         return None, None
 
     app_data = config['apps'][instance]
+
+    # Handle a missing `redirect_uri`
+    if 'redirect_uri' not in app_data:
+        app_data['redirect_uri'] = 'urn:ietf:wg:oauth:2.0:oob'
+
     return User(**user_data), App(**app_data)
 
 
@@ -97,6 +102,8 @@ def load_app(instance: str, redirect_uri: str) -> Optional[App]:
         # have worked with OOB and there's no need for a `redirect_uri` update.  Maybe?
         if a.redirect_uri == "":
             a.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
+        if a.redirect_uri != redirect_uri:
+            a.redirect_uri = redirect_uri
         return a
 
 

--- a/toot/config.py
+++ b/toot/config.py
@@ -87,10 +87,17 @@ def get_user_app(user_id: str):
     return extract_user_app(load_config(), user_id)
 
 
-def load_app(instance: str) -> Optional[App]:
+def load_app(instance: str, redirect_uri: str) -> Optional[App]:
     config = load_config()
     if instance in config['apps']:
-        return App(**config['apps'][instance])
+        a = App(**config['apps'][instance])
+        # Not sure about this bit - if an app was stored without a `redirect_uri`, should
+        # loading update it to OOB (the previous default) or to the requested `redirect_uri`?
+        # Stick to OOB for now because presumably if we've saved the app, the login must
+        # have worked with OOB and there's no need for a `redirect_uri` update.  Maybe?
+        if a.redirect_uri == "":
+            a.redirect_uri = "urn:ietf:wg:oauth:2.0:oob"
+        return a
 
 
 def load_user(user_id: str, throw=False):


### PR DESCRIPTION
Pixelfed instances do not handle OOB OAuth correctly meaning you can't currently login to them using `toot` (e.g. https://github.com/pixelfed/pixelfed/issues/2522 )

This is a fudge to workaround that by allowing you to specify an alternate `redirect_uri` for broken servers which can take the HTTP redirect issued by Pixelfed and let you grab the code.

If you don't have a handy HTTP server, you can use `http://localhost` and your browser (at least Safari and Chrome) will have the code in the address bar for copying and pasting into `toot`.

I'm not 100% sure about how an empty `redirect_uri` is handled in `load_app` - it feels like supplying `-r` should set that instead of OOB on an app without an explicit setting but I don't think it's a situation that's going to crop up that often anyway.

(Apologies if this is a Pythonic mess, it's not one of my main languages)