### PR TITLE
Allow divergence in API

### DIFF
--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -210,7 +210,6 @@ class TUI(urwid.Frame):
                     self.loop.set_alarm_in(0, lambda *args: done_callback(result))
             except Exception as ex:
                 exception = ex
-                logger.exception(exception)
                 self.loop.set_alarm_in(0, lambda *args: _error_callback(exception))
 
         # TODO: replace by `self.loop.event_loop.run_in_executor` at some point

--- a/toot/tui/overlays.py
+++ b/toot/tui/overlays.py
@@ -349,7 +349,7 @@ class Account(urwid.ListBox):
                 for line in widgetlist:
                     yield (line)
 
-                if field["verified_at"]:
+                if 'verified_at' in field and field["verified_at"]:
                     yield urwid.Text(("success", "✓ Verified"))
 
         yield urwid.Divider()


### PR DESCRIPTION
I'm using pleroma which doesn't have the same api:

- `/api/v1/preferences` doesn't exist
- `verified_at` doesn't always exist in a profile's field

Those changes make the absence of the first less verbose (instead of logging the exception inside the ui and mucking up the whole display, only the "Press X to view" is displayed) and the absence of the second one not crash

Thanks for this tool !