### PR TITLE
Handle urwid API deprecations

### DIFF
--- a/toot/tui/timeline.py
+++ b/toot/tui/timeline.py
@@ -338,9 +338,9 @@ class Timeline(urwid.Columns):
                 pass
         if img:
             try:
-                status.placeholders[placeholder_index]._set_original_widget(
-                    graphics_widget(img, image_format=self.tui.options.image_format, corner_radius=10,
-                                    colors=self.tui.options.colors))
+                status.placeholders[placeholder_index].original_widget = graphics_widget(
+                    img, image_format=self.tui.options.image_format, corner_radius=10, colors=self.tui.options.colors
+                )
 
             except IndexError:
                 # ignore IndexErrors.

--- a/toot/tui/widgets.py
+++ b/toot/tui/widgets.py
@@ -58,7 +58,7 @@ class CheckBox(urwid.AttrWrap):
 
     def get_state(self):
         """Return the state of the checkbox."""
-        return self.button._state
+        return self.button.get_state()
 
 
 class RadioButton(urwid.AttrWrap):


### PR DESCRIPTION
* `_set_original_widget` -> `original_widget` property (setter)
* `button._state` -> `button.get_state()` (not deprecated, but we have public getter)