### PR TITLE
Fix Missing pysocks Dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "click~=8.1",
     "python-dateutil>=2.8.1,<3.0",
     "requests>=2.13,<3.0",
+    "pysocks>=1.7.1",
     "tomlkit>=0.10.0,<1.0",
     "urwid>=2.0.0,<3.0",
     "wcwidth>=0.1.7",


### PR DESCRIPTION
When starting `toot tui` with `HTTPS_PROXY` set to a `socks5h` uri, an exception is thrown.

execute:
`HTTPS_PROXY="socks5h://localhost:9050" toot tui`

result:
```
  File "/home/account/.local/venv/test/lib/python3.11/site-packages/requests/adapters.py", line 483, in get_connection_with_tls_context
    proxy_manager = self.proxy_manager_for(proxy)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/account/.local/venv/test/lib/python3.11/site-packages/requests/adapters.py", line 282, in proxy_manager_for
    manager = self.proxy_manager[proxy] = SOCKSProxyManager(
                                          ^^^^^^^^^^^^^^^^^^
  File "/home/account/.local/venv/test/lib/python3.11/site-packages/requests/adapters.py", line 64, in SOCKSProxyManager
    raise InvalidSchema("Missing dependencies for SOCKS support.")
requests.exceptions.InvalidSchema: Missing dependencies for SOCKS support.
```

`requests` needs the `pysocks` library to function in this case. This PR adds the dependency. This shouldn't be a big issue downstream, as `pysocks` is already commonly packaged in Linux distributions.