### PR TITLE
Fix: properly handle media_viewer commands with arguments

### DIFF
--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -582,7 +582,9 @@ class TUI(urwid.Frame):
         media_viewer = self.options.media_viewer
         if media_viewer:
             try:
-                subprocess.run([media_viewer] + urls)
+                command = media_viewer.split()
+                command.extend(urls)
+                subprocess.run(command)
             except FileNotFoundError:
                 self.footer.set_error_message(f"Media viewer not found: '{media_viewer}'")
             except Exception as ex:


### PR DESCRIPTION
This allows the `media_viewer` to be configured with both simple commands `feh` and commands with arguments `kitten icat`