### PR TITLE
Sanitize and truncate link descriptions in status links overlay

### DIFF
--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -405,7 +405,16 @@ class TUI(urwid.Frame):
 
         for a in post_attachments + reblog_attachments:
             url = a["remote_url"] or a["url"]
-            links.append((url, a["description"] if a["description"] else url))
+            url = url.strip()
+            description = a["description"] if a["description"] else url
+            # Sanitize: remove newlines, collapse multiple spaces
+            sanitized_desc = ' '.join(description.replace('\n', ' ').replace('\r', ' ').split())
+            # Truncate to 120 chars with ellipsis if needed
+            if len(sanitized_desc) > 120:
+                truncated_desc = sanitized_desc[:117] + "..."
+            else:
+                truncated_desc = sanitized_desc
+            links.append((url, truncated_desc))
 
         def _clear(*args):
             self.clear_screen()


### PR DESCRIPTION
Sanitize URLs and descriptions by removing newlines, collapsing spaces, and truncating long descriptions.

Fixes incorrect display of links found on https://alaskan.social/@Ghostsheetz/115170387284357038

<img width="2147" height="546" alt="link_description" src="https://github.com/user-attachments/assets/6a955a9a-bafd-4d16-b5b0-681fda129cbd" />
