### PR TITLE
Fix broken tui.palette support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           uv sync
       - name: Run tests
         run: |
-          uv run pytest
+          uv run --all-extras pytest
       - name: Validate minimum required version
         run: |
-          uv run vermin --no-tips toot
+          uv run --all-extras vermin --no-tips toot

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -62,7 +62,7 @@ arguments. This works well with image viewers like `feh` which accept URLs as
 arguments.
 
 ```toml
-[tui]
+[commands.tui]
 media_viewer = "feh"
 ```
 
@@ -73,7 +73,7 @@ TUI uses Urwid which provides several color modes. See
 for more details.
 
 By default, TUI operates in 16-color mode which can be changed by setting the
-`color` setting in the `[tui]` section to one of the following values:
+`color` setting in the `[commands.tui]` section to one of the following values:
 
 * `1` (monochrome)
 * `16` (default)
@@ -82,7 +82,7 @@ By default, TUI operates in 16-color mode which can be changed by setting the
 * `16777216` (24 bit)
 
 TUI defines a list of colors which can be customized, currently they can be seen
-[in the source code](https://github.com/ihabunek/toot/blob/master/toot/tui/constants.py). They can be overridden in the `[tui.palette]` section.
+[in the source code](https://github.com/ihabunek/toot/blob/master/toot/tui/constants.py). They can be overridden in the `[commands.tui.palette]` section.
 
 Each color is defined as a list of upto 5 values:
 
@@ -98,7 +98,7 @@ to an empty string.
 For example, to change the button colors in 16 color mode:
 
 ```toml
-[tui.palette]
+[commands.tui.palette]
 button = ["dark red,bold", ""]
 button_focused = ["light gray", "green"]
 ```
@@ -106,10 +106,10 @@ button_focused = ["light gray", "green"]
 In monochrome mode:
 
 ```toml
-[tui]
+[commands.tui]
 colors = 1
 
-[tui.palette]
+[commands.tui.palette]
 button = ["", "", "bold"]
 button_focused = ["", "", "italics"]
 ```
@@ -117,10 +117,10 @@ button_focused = ["", "", "italics"]
 In 256 color mode:
 
 ```toml
-[tui]
+[commands.tui]
 colors = 256
 
-[tui.palette]
+[commands.tui.palette]
 button = ["", "", "", "#aaa", "#bbb"]
 button_focused = ["", "", "", "#aaa", "#bbb"]
 ```

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -105,7 +105,7 @@ class TUI(urwid.Frame):
         tui = TUI(app, user, screen, options)
 
         palette = PALETTE.copy()
-        overrides = settings.get_setting("tui.palette", dict, {})
+        overrides = settings.get_setting("commands.tui.palette", dict, {})
         for name, styles in overrides.items():
             palette.append(tuple([name] + styles))
 

--- a/toot/tui/app.py
+++ b/toot/tui/app.py
@@ -29,6 +29,7 @@ urwid.set_encoding('UTF-8')
 
 
 DEFAULT_MAX_TOOT_CHARS = 500
+DEFAULT_PALETTE_KEY = 'default'
 
 
 class TuiOptions(NamedTuple):
@@ -116,6 +117,9 @@ class TUI(urwid.Frame):
             unhandled_input=tui.unhandled_input,
             screen=screen,
         )
+        for name, *styles in palette:
+            if name == DEFAULT_PALETTE_KEY:
+                loop.screen.register_palette_entry(None, *styles)
         tui.loop = loop
 
         return tui

--- a/toot/tui/constants.py
+++ b/toot/tui/constants.py
@@ -11,6 +11,9 @@
 # http://urwid.org/manual/displayattributes.html#using-display-attributes
 
 PALETTE = [
+    # Default
+    ('default', 'white', 'black'),
+
     # Components
     ('button', 'white', 'black'),
     ('button_focused', 'light gray', 'dark magenta', 'bold,underline'),


### PR DESCRIPTION
- Fixing what broke (I believe) when moving from `[tui]` to `[commands.tui]`, including the docs.
- Adding a `default` palette key that is applied to all unstyled content (via [urwid's `None` handling](http://urwid.org/manual/displayattributes.html#using-display-attributes))