### PR TITLE
Fix backspace for wide chars in post

### DIFF
--- a/toot/utils/__init__.py
+++ b/toot/utils/__init__.py
@@ -6,6 +6,7 @@ import subprocess
 import tempfile
 import unicodedata
 import warnings
+import readline
 
 from bs4 import BeautifulSoup
 from importlib.metadata import version


### PR DESCRIPTION
When inputting wide characters (e.g. CJK, emoji) via input(), pressing backspace deleted only one byte at a time instead of one character, causing utf-8 decode error.

Fix by importing readline.