### PR TITLE
Fix table column alignment for wide characters

### DIFF
--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,22 @@
+from wcwidth import wcswidth
+
+from toot.output import print_table
+
+
+def test_print_table_aligns_wide_characters(capsys):
+    # The Title column mixes ASCII and CJK entries. CJK characters occupy two
+    # terminal cells each, so column widths and padding must be measured in
+    # display columns rather than character count. When they are, every
+    # rendered row occupies the same total display width.
+    print_table(
+        ["ID", "Title"],
+        [
+            ["1", "Hello"],
+            ["2", "日本語"],
+        ],
+    )
+
+    lines = capsys.readouterr().out.splitlines()
+    display_widths = {wcswidth(line) for line in lines}
+
+    assert len(display_widths) == 1

--- a/toot/output.py
+++ b/toot/output.py
@@ -8,7 +8,7 @@ from wcwidth import wcswidth
 
 from toot.entities import Account, Instance, List, Notification, Poll, Status
 from toot.utils import get_text, html_to_paragraphs
-from toot.wcstring import wc_wrap
+from toot.wcstring import pad, wc_wrap
 
 DEFAULT_WIDTH = 80
 
@@ -138,13 +138,13 @@ def print_lists(lists: t.List[List]):
 
 
 def print_table(headers: t.List[str], data: t.List[t.List[str]]):
-    widths = [[len(cell) for cell in row] for row in data + [headers]]
+    widths = [[wcswidth(cell) for cell in row] for row in data + [headers]]
     widths = [max(width) for width in zip(*widths)]
 
     def print_row(row):
         for idx, cell in enumerate(row):
             width = widths[idx]
-            click.echo(cell.ljust(width), nl=False)
+            click.echo(pad(cell, width), nl=False)
             click.echo("  ", nl=False)
         click.echo()
 


### PR DESCRIPTION
## Summary

`print_table` (used by `toot lists`) sized its columns with `len(cell)` and padded them with `str.ljust(width)`. Both count code points, not terminal cells, so wide characters break the layout: CJK and emoji take two cells but were counted as one, which pushes every following column out of alignment.

The fix measures widths with `wcswidth()` and pads with `wcstring.pad()`, the wide-character aware helper already in the codebase. `wcswidth()` is also what `status_lines` uses to align the status header, so this just brings the table in line with the rest of the module. ASCII tables are unchanged.

## Before (a list whose title contains CJK)

```
ID  Title    Replies
--  -------  --------
1   Hello    list
2   日本語のリスト  followed
```

## After

```
ID  Title           Replies
--  --------------  --------
1   Hello           list
2   日本語のリスト  followed
```

## Tests

Added `tests/test_output.py`, which renders a table mixing ASCII and CJK rows and asserts every row ends up the same display width. It fails on the old code and passes with the fix. `pytest`, `flake8` and `vermin` all pass locally.
